### PR TITLE
feat: 기본 설정된 아기 조회 API 구현

### DIFF
--- a/back/src/main/java/com/baba/back/baby/controller/BabyController.java
+++ b/back/src/main/java/com/baba/back/baby/controller/BabyController.java
@@ -1,0 +1,21 @@
+package com.baba.back.baby.controller;
+
+import com.baba.back.baby.dto.SearchDefaultBabyResponse;
+import com.baba.back.baby.service.BabyService;
+import com.baba.back.oauth.support.Login;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class BabyController {
+
+    private final BabyService babyService;
+
+    @GetMapping("/baby/default")
+    public ResponseEntity<SearchDefaultBabyResponse> searchDefaultBaby(@Login String memberId) {
+        return ResponseEntity.ok().body(babyService.searchDefaultBaby(memberId));
+    }
+}

--- a/back/src/main/java/com/baba/back/baby/domain/Babies.java
+++ b/back/src/main/java/com/baba/back/baby/domain/Babies.java
@@ -13,7 +13,7 @@ public class Babies {
         this.babies = new ArrayList<>(babies);
     }
 
-    private static void validateEmpty(List<Baby> babies) {
+    private void validateEmpty(List<Baby> babies) {
         if (babies.isEmpty()) {
             throw new BabiesBadRequestException("babies의 길이는 0일 수 없습니다.");
         }

--- a/back/src/main/java/com/baba/back/baby/domain/Babies.java
+++ b/back/src/main/java/com/baba/back/baby/domain/Babies.java
@@ -1,0 +1,30 @@
+package com.baba.back.baby.domain;
+
+import com.baba.back.baby.exception.BabiesBadRequestException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class Babies {
+    private final List<Baby> babies;
+
+    public Babies(List<Baby> babies) {
+        validateEmpty(babies);
+        this.babies = new ArrayList<>(babies);
+    }
+
+    private static void validateEmpty(List<Baby> babies) {
+        if (babies.isEmpty()) {
+            throw new BabiesBadRequestException("babies의 길이는 0일 수 없습니다.");
+        }
+    }
+
+    public Baby getDefaultBaby() {
+        validateEmpty(babies);
+        return babies.get(0);
+    }
+
+    public List<Baby> getNotDefaultBabies() {
+        return Collections.unmodifiableList(babies.subList(1, babies.size()));
+    }
+}

--- a/back/src/main/java/com/baba/back/baby/domain/Baby.java
+++ b/back/src/main/java/com/baba/back/baby/domain/Baby.java
@@ -25,7 +25,8 @@ public class Baby {
     private Birthday birthday;
 
     @Builder
-    public Baby(String name, LocalDate birthday, LocalDate now) {
+    public Baby(String id, String name, LocalDate birthday, LocalDate now) {
+        this.id = id;
         this.id = UUID.randomUUID().toString();
         this.name = new Name(name);
         this.birthday = Birthday.of(birthday, now);

--- a/back/src/main/java/com/baba/back/baby/domain/Baby.java
+++ b/back/src/main/java/com/baba/back/baby/domain/Baby.java
@@ -5,7 +5,6 @@ import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import java.time.LocalDate;
-import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -27,7 +26,6 @@ public class Baby {
     @Builder
     public Baby(String id, String name, LocalDate birthday, LocalDate now) {
         this.id = id;
-        this.id = UUID.randomUUID().toString();
         this.name = new Name(name);
         this.birthday = Birthday.of(birthday, now);
     }

--- a/back/src/main/java/com/baba/back/baby/domain/IdConstructor.java
+++ b/back/src/main/java/com/baba/back/baby/domain/IdConstructor.java
@@ -1,0 +1,5 @@
+package com.baba.back.baby.domain;
+
+public interface IdConstructor {
+    String createId();
+}

--- a/back/src/main/java/com/baba/back/baby/domain/UUIDConstructor.java
+++ b/back/src/main/java/com/baba/back/baby/domain/UUIDConstructor.java
@@ -1,0 +1,13 @@
+package com.baba.back.baby.domain;
+
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UUIDConstructor implements IdConstructor {
+
+    @Override
+    public String createId() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/back/src/main/java/com/baba/back/baby/dto/BabyRequest.java
+++ b/back/src/main/java/com/baba/back/baby/dto/BabyRequest.java
@@ -20,8 +20,9 @@ public class BabyRequest {
     @NotNull
     private LocalDate birthday;
 
-    public Baby toEntity(LocalDate now) {
+    public Baby toEntity(String id, LocalDate now) {
         return Baby.builder()
+                .id(id)
                 .name(babyName)
                 .birthday(birthday)
                 .now(now)

--- a/back/src/main/java/com/baba/back/baby/dto/SearchDefaultBabyResponse.java
+++ b/back/src/main/java/com/baba/back/baby/dto/SearchDefaultBabyResponse.java
@@ -1,0 +1,10 @@
+package com.baba.back.baby.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SearchDefaultBabyResponse {
+    private String babyId;
+}

--- a/back/src/main/java/com/baba/back/baby/exception/BabiesBadRequestException.java
+++ b/back/src/main/java/com/baba/back/baby/exception/BabiesBadRequestException.java
@@ -1,0 +1,9 @@
+package com.baba.back.baby.exception;
+
+import com.baba.back.exception.BadRequestException;
+
+public class BabiesBadRequestException extends BadRequestException {
+    public BabiesBadRequestException(String message) {
+        super(message);
+    }
+}

--- a/back/src/main/java/com/baba/back/baby/service/BabyService.java
+++ b/back/src/main/java/com/baba/back/baby/service/BabyService.java
@@ -17,7 +17,7 @@ public class BabyService {
     public SearchDefaultBabyResponse searchDefaultBaby(String memberId) {
         Relation relation = relationRepository.findByMemberIdAndDefaultRelation(memberId, DefaultRelation.DEFAULT)
                 .orElseThrow(
-                        () -> new RelationNotFoundException(String.format("%s 는 Relation 테이블에 존재하지 않습니다.", memberId)));
+                        () -> new RelationNotFoundException(memberId +" 에 해당하는 relation 이 존재하지 않습니다."));
 
         return new SearchDefaultBabyResponse(relation.getBaby().getId());
     }

--- a/back/src/main/java/com/baba/back/baby/service/BabyService.java
+++ b/back/src/main/java/com/baba/back/baby/service/BabyService.java
@@ -16,7 +16,7 @@ public class BabyService {
     public SearchDefaultBabyResponse searchDefaultBaby(String memberId) {
         Relation relation = relationRepository.findByMemberIdAndDefaultRelation(memberId, true)
                 .orElseThrow(
-                        () -> new RelationNotFoundException(memberId +" 에 해당하는 relation 이 존재하지 않습니다."));
+                        () -> new RelationNotFoundException(memberId + " 에 해당하는 relation 이 존재하지 않습니다."));
 
         return new SearchDefaultBabyResponse(relation.getBabyId());
     }

--- a/back/src/main/java/com/baba/back/baby/service/BabyService.java
+++ b/back/src/main/java/com/baba/back/baby/service/BabyService.java
@@ -1,7 +1,6 @@
 package com.baba.back.baby.service;
 
 import com.baba.back.baby.dto.SearchDefaultBabyResponse;
-import com.baba.back.relation.domain.DefaultRelation;
 import com.baba.back.relation.domain.Relation;
 import com.baba.back.relation.exception.RelationNotFoundException;
 import com.baba.back.relation.repository.RelationRepository;
@@ -15,11 +14,11 @@ public class BabyService {
     private final RelationRepository relationRepository;
 
     public SearchDefaultBabyResponse searchDefaultBaby(String memberId) {
-        Relation relation = relationRepository.findByMemberIdAndDefaultRelation(memberId, DefaultRelation.DEFAULT)
+        Relation relation = relationRepository.findByMemberIdAndDefaultRelation(memberId, true)
                 .orElseThrow(
                         () -> new RelationNotFoundException(memberId +" 에 해당하는 relation 이 존재하지 않습니다."));
 
-        return new SearchDefaultBabyResponse(relation.getBaby().getId());
+        return new SearchDefaultBabyResponse(relation.getBabyId());
     }
 
 }

--- a/back/src/main/java/com/baba/back/baby/service/BabyService.java
+++ b/back/src/main/java/com/baba/back/baby/service/BabyService.java
@@ -1,0 +1,25 @@
+package com.baba.back.baby.service;
+
+import com.baba.back.baby.dto.SearchDefaultBabyResponse;
+import com.baba.back.relation.domain.DefaultRelation;
+import com.baba.back.relation.domain.Relation;
+import com.baba.back.relation.exception.RelationNotFoundException;
+import com.baba.back.relation.repository.RelationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BabyService {
+
+    private final RelationRepository relationRepository;
+
+    public SearchDefaultBabyResponse searchDefaultBaby(String memberId) {
+        Relation relation = relationRepository.findByMemberIdAndDefaultRelation(memberId, DefaultRelation.DEFAULT)
+                .orElseThrow(
+                        () -> new RelationNotFoundException(String.format("%s 는 Relation 테이블에 존재하지 않습니다.", memberId)));
+
+        return new SearchDefaultBabyResponse(relation.getBaby().getId());
+    }
+
+}

--- a/back/src/main/java/com/baba/back/oauth/service/MemberService.java
+++ b/back/src/main/java/com/baba/back/oauth/service/MemberService.java
@@ -12,7 +12,6 @@ import com.baba.back.oauth.exception.JoinedMemberBadRequestException;
 import com.baba.back.oauth.exception.JoinedMemberNotFoundException;
 import com.baba.back.oauth.repository.JoinedMemberRepository;
 import com.baba.back.oauth.repository.MemberRepository;
-import com.baba.back.relation.domain.DefaultRelation;
 import com.baba.back.relation.domain.Relation;
 import com.baba.back.relation.domain.RelationGroup;
 import com.baba.back.relation.repository.RelationRepository;
@@ -80,7 +79,7 @@ public class MemberService {
                 .baby(babies.get(0))
                 .relationName(relationName)
                 .relationGroup(RelationGroup.FAMILY)
-                .defaultRelation(DefaultRelation.DEFAULT)
+                .defaultRelation(true)
                 .build();
 
         relationRepository.save(defaultRelation);
@@ -93,7 +92,7 @@ public class MemberService {
                         .baby(baby)
                         .relationName(relationName)
                         .relationGroup(RelationGroup.FAMILY)
-                        .defaultRelation(DefaultRelation.NOT_DEFAULT)
+                        .defaultRelation(false)
                         .build())
                 .forEach(relationRepository::save);
     }

--- a/back/src/main/java/com/baba/back/oauth/service/MemberService.java
+++ b/back/src/main/java/com/baba/back/oauth/service/MemberService.java
@@ -11,12 +11,14 @@ import com.baba.back.oauth.exception.JoinedMemberBadRequestException;
 import com.baba.back.oauth.exception.JoinedMemberNotFoundException;
 import com.baba.back.oauth.repository.JoinedMemberRepository;
 import com.baba.back.oauth.repository.MemberRepository;
+import com.baba.back.relation.domain.DefaultRelation;
 import com.baba.back.relation.domain.Relation;
 import com.baba.back.relation.domain.RelationGroup;
 import com.baba.back.relation.repository.RelationRepository;
 import jakarta.transaction.Transactional;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -70,12 +72,25 @@ public class MemberService {
     }
 
     private void saveRelations(List<Baby> babies, Member member, String relationName) {
-        babies.stream()
+        Relation defaultRelation = Relation.builder()
+                .member(member)
+                .baby(babies.get(0))
+                .relationName(relationName)
+                .relationGroup(RelationGroup.FAMILY)
+                .defaultRelation(DefaultRelation.DEFAULT)
+                .build();
+
+        relationRepository.save(defaultRelation);
+
+        IntStream
+                .range(1, babies.size())
+                .mapToObj(babies::get)
                 .map(baby -> Relation.builder()
                         .member(member)
                         .baby(baby)
                         .relationName(relationName)
                         .relationGroup(RelationGroup.FAMILY)
+                        .defaultRelation(DefaultRelation.NOT_DEFAULT)
                         .build())
                 .forEach(relationRepository::save);
     }

--- a/back/src/main/java/com/baba/back/oauth/service/MemberService.java
+++ b/back/src/main/java/com/baba/back/oauth/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.baba.back.oauth.service;
 
 import com.baba.back.baby.domain.Baby;
+import com.baba.back.baby.domain.IdConstructor;
 import com.baba.back.baby.repository.BabyRepository;
 import com.baba.back.oauth.domain.ColorPicker;
 import com.baba.back.oauth.domain.JoinedMember;
@@ -32,6 +33,7 @@ public class MemberService {
     private final BabyRepository babyRepository;
     private final RelationRepository relationRepository;
     private final ColorPicker<String> colorPicker;
+    private final IdConstructor idConstructor;
 
     private final LocalDate now = LocalDate.now();
 
@@ -65,8 +67,9 @@ public class MemberService {
     }
 
     private List<Baby> saveBabies(MemberJoinRequest request) {
+        String babyId = idConstructor.createId();
         return request.getBabies().stream()
-                .map(babyRequest -> babyRequest.toEntity(now))
+                .map(babyRequest -> babyRequest.toEntity(babyId, now))
                 .map(babyRepository::save)
                 .toList();
     }

--- a/back/src/main/java/com/baba/back/oauth/service/MemberService.java
+++ b/back/src/main/java/com/baba/back/oauth/service/MemberService.java
@@ -72,6 +72,11 @@ public class MemberService {
     }
 
     private void saveRelations(Babies babies, Member member, String relationName) {
+        saveDefaultRelation(babies, member, relationName);
+        saveNotDefaultRelations(babies, member, relationName);
+    }
+
+    private void saveDefaultRelation(Babies babies, Member member, String relationName) {
         relationRepository.save(Relation.builder()
                 .member(member)
                 .baby(babies.getDefaultBaby())
@@ -79,7 +84,9 @@ public class MemberService {
                 .relationGroup(RelationGroup.FAMILY)
                 .defaultRelation(true)
                 .build());
+    }
 
+    private void saveNotDefaultRelations(Babies babies, Member member, String relationName) {
         babies.getNotDefaultBabies()
                 .stream()
                 .map(baby -> Relation.builder()

--- a/back/src/main/java/com/baba/back/relation/domain/DefaultRelation.java
+++ b/back/src/main/java/com/baba/back/relation/domain/DefaultRelation.java
@@ -1,5 +1,0 @@
-package com.baba.back.relation.domain;
-
-public enum DefaultRelation {
-    DEFAULT, NOT_DEFAULT
-}

--- a/back/src/main/java/com/baba/back/relation/domain/DefaultRelation.java
+++ b/back/src/main/java/com/baba/back/relation/domain/DefaultRelation.java
@@ -1,0 +1,5 @@
+package com.baba.back.relation.domain;
+
+public enum DefaultRelation {
+    DEFAULT, NOT_DEFAULT
+}

--- a/back/src/main/java/com/baba/back/relation/domain/Relation.java
+++ b/back/src/main/java/com/baba/back/relation/domain/Relation.java
@@ -52,4 +52,8 @@ public class Relation {
         this.relationGroup = relationGroup;
         this.defaultRelation = defaultRelation;
     }
+
+    public String getBabyId() {
+        return baby.getId();
+    }
 }

--- a/back/src/main/java/com/baba/back/relation/domain/Relation.java
+++ b/back/src/main/java/com/baba/back/relation/domain/Relation.java
@@ -40,12 +40,11 @@ public class Relation {
     @Enumerated(EnumType.STRING)
     private RelationGroup relationGroup;
 
-    @Enumerated(EnumType.STRING)
-    private DefaultRelation defaultRelation;
+    private boolean defaultRelation;
 
     @Builder
     public Relation(Long id, Member member, Baby baby, String relationName, RelationGroup relationGroup,
-                    DefaultRelation defaultRelation) {
+                    boolean defaultRelation) {
         this.id = id;
         this.member = member;
         this.baby = baby;

--- a/back/src/main/java/com/baba/back/relation/domain/Relation.java
+++ b/back/src/main/java/com/baba/back/relation/domain/Relation.java
@@ -40,12 +40,17 @@ public class Relation {
     @Enumerated(EnumType.STRING)
     private RelationGroup relationGroup;
 
+    @Enumerated(EnumType.STRING)
+    private DefaultRelation defaultRelation;
+
     @Builder
-    public Relation(Long id, Member member, Baby baby, String relationName, RelationGroup relationGroup) {
+    public Relation(Long id, Member member, Baby baby, String relationName, RelationGroup relationGroup,
+                    DefaultRelation defaultRelation) {
         this.id = id;
         this.member = member;
         this.baby = baby;
         this.relationName = new Name(relationName);
         this.relationGroup = relationGroup;
+        this.defaultRelation = defaultRelation;
     }
 }

--- a/back/src/main/java/com/baba/back/relation/exception/RelationNotFoundException.java
+++ b/back/src/main/java/com/baba/back/relation/exception/RelationNotFoundException.java
@@ -1,0 +1,9 @@
+package com.baba.back.relation.exception;
+
+import com.baba.back.exception.NotFoundException;
+
+public class RelationNotFoundException extends NotFoundException {
+    public RelationNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/back/src/main/java/com/baba/back/relation/repository/RelationRepository.java
+++ b/back/src/main/java/com/baba/back/relation/repository/RelationRepository.java
@@ -1,10 +1,14 @@
 package com.baba.back.relation.repository;
 
 import com.baba.back.oauth.domain.member.Member;
+import com.baba.back.relation.domain.DefaultRelation;
 import com.baba.back.relation.domain.Relation;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RelationRepository extends JpaRepository<Relation, Long> {
     List<Relation> findAllByMember(Member member);
+
+    Optional<Relation> findByMemberIdAndDefaultRelation(String memberId, DefaultRelation defaultRelation);
 }

--- a/back/src/main/java/com/baba/back/relation/repository/RelationRepository.java
+++ b/back/src/main/java/com/baba/back/relation/repository/RelationRepository.java
@@ -1,7 +1,6 @@
 package com.baba.back.relation.repository;
 
 import com.baba.back.oauth.domain.member.Member;
-import com.baba.back.relation.domain.DefaultRelation;
 import com.baba.back.relation.domain.Relation;
 import java.util.List;
 import java.util.Optional;
@@ -10,5 +9,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface RelationRepository extends JpaRepository<Relation, Long> {
     List<Relation> findAllByMember(Member member);
 
-    Optional<Relation> findByMemberIdAndDefaultRelation(String memberId, DefaultRelation defaultRelation);
+    Optional<Relation> findByMemberIdAndDefaultRelation(String memberId, boolean defaultRelation);
 }

--- a/back/src/test/java/com/baba/back/baby/acceptance/BabyAcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/baby/acceptance/BabyAcceptanceTest.java
@@ -111,7 +111,9 @@ public class BabyAcceptanceTest extends AcceptanceTest {
 
         // then
         assertAll(
-                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value())
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.response().jsonPath().getString("babyId")).isEqualTo(BABY_ID)
         );
+
     }
 }

--- a/back/src/test/java/com/baba/back/baby/acceptance/BabyAcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/baby/acceptance/BabyAcceptanceTest.java
@@ -1,36 +1,37 @@
-package com.baba.back.baby.service;
+package com.baba.back.baby.acceptance;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.baba.back.AcceptanceTest;
 import com.baba.back.baby.domain.Baby;
-import com.baba.back.baby.dto.SearchDefaultBabyResponse;
 import com.baba.back.baby.repository.BabyRepository;
 import com.baba.back.oauth.domain.ColorPicker;
 import com.baba.back.oauth.domain.member.Member;
 import com.baba.back.oauth.repository.MemberRepository;
+import com.baba.back.oauth.service.TokenProvider;
 import com.baba.back.relation.domain.DefaultRelation;
 import com.baba.back.relation.domain.Relation;
 import com.baba.back.relation.domain.RelationGroup;
-import com.baba.back.relation.exception.RelationNotFoundException;
 import com.baba.back.relation.repository.RelationRepository;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.http.HttpStatus;
 
-@Transactional
-@SpringBootTest
-class BabyServiceTest {
+public class BabyAcceptanceTest extends AcceptanceTest {
     public static final String MEMBER_ID = "1234";
     public static final String BABY_ID = "1234";
-
-    // 디폴트 아기 조회 API에 대한 테스트
+    public static final String BABY_BASE_PATH = "/baby";
 
     @Autowired
-    private BabyService babyService;
+    private TokenProvider tokenProvider;
 
     @Autowired
     private MemberRepository memberRepository;
@@ -41,20 +42,38 @@ class BabyServiceTest {
     @Autowired
     private RelationRepository relationRepository;
 
+    @AfterEach
+    void 초기화() {
+        relationRepository.deleteAll();
+        memberRepository.deleteAll();
+        babyRepository.deleteAll();
+    }
+
     @Test
-    void 멤버가_관계_테이블에_없다면_예외를_던진다() {
-        // given크
+    void 관계가_없으면_404를_던진다() {
+        // given
+        final String token = tokenProvider.createToken(MEMBER_ID);
 
         // when
+        ExtractableResponse<Response> response = RestAssured.given()
+                .headers(Map.of("Authorization", "Bearer " + token))
+                .when()
+                .get(BABY_BASE_PATH + "/default")
+                .then()
+                .log().all()
+                .extract();
 
         // then
-        assertThatThrownBy(() -> babyService.searchDefaultBaby(MEMBER_ID))
-                .isInstanceOf(RelationNotFoundException.class);
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value())
+        );
     }
 
     @Test
     void 디폴트_아기를_조회한다() {
         // given
+        final String token = tokenProvider.createToken(MEMBER_ID);
+
         LocalDate birthday = LocalDate.of(2024, 1, 25);
         LocalDate now = LocalDate.of(2023, 1, 25);
         final String color = "FFAEBA";
@@ -84,9 +103,17 @@ class BabyServiceTest {
                 .build());
 
         // when
-        SearchDefaultBabyResponse response = babyService.searchDefaultBaby(MEMBER_ID);
+        ExtractableResponse<Response> response = RestAssured.given()
+                .headers(Map.of("Authorization", "Bearer " + token))
+                .when()
+                .get(BABY_BASE_PATH + "/default")
+                .then()
+                .log().all()
+                .extract();
 
         // then
-        assertThat(response.getBabyId()).isEqualTo(BABY_ID);
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value())
+        );
     }
 }

--- a/back/src/test/java/com/baba/back/baby/acceptance/BabyAcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/baby/acceptance/BabyAcceptanceTest.java
@@ -10,7 +10,6 @@ import com.baba.back.oauth.domain.ColorPicker;
 import com.baba.back.oauth.domain.member.Member;
 import com.baba.back.oauth.repository.MemberRepository;
 import com.baba.back.oauth.service.TokenProvider;
-import com.baba.back.relation.domain.DefaultRelation;
 import com.baba.back.relation.domain.Relation;
 import com.baba.back.relation.domain.RelationGroup;
 import com.baba.back.relation.repository.RelationRepository;
@@ -97,7 +96,7 @@ public class BabyAcceptanceTest extends AcceptanceTest {
                 .baby(baby)
                 .relationName("엄마")
                 .relationGroup(RelationGroup.FAMILY)
-                .defaultRelation(DefaultRelation.DEFAULT)
+                .defaultRelation(true)
                 .build());
 
         // when

--- a/back/src/test/java/com/baba/back/baby/acceptance/BabyAcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/baby/acceptance/BabyAcceptanceTest.java
@@ -50,7 +50,7 @@ public class BabyAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 관계가_없으면_404를_던진다() {
+    void 기본_설정된_아기가_없으면_404를_던진다() {
         // given
         final String token = tokenProvider.createToken(MEMBER_ID);
 

--- a/back/src/test/java/com/baba/back/baby/acceptance/BabyAcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/baby/acceptance/BabyAcceptanceTest.java
@@ -64,9 +64,7 @@ public class BabyAcceptanceTest extends AcceptanceTest {
                 .extract();
 
         // then
-        assertAll(
-                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value())
-        );
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
     }
 
     @Test

--- a/back/src/test/java/com/baba/back/baby/domain/BabiesTest.java
+++ b/back/src/test/java/com/baba/back/baby/domain/BabiesTest.java
@@ -1,12 +1,19 @@
 package com.baba.back.baby.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.baba.back.baby.exception.BabiesBadRequestException;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class BabiesTest {
+    public static final String BABY_ID = "1234";
+    public static final String BABY_NAME = "앙쥬";
+    private static final LocalDate NOW = LocalDate.now();
+    private static final LocalDate BIRTHDAY = LocalDate.of(2023, 7, 7);
 
     @Test
     void 아기_리스트의_길이가_0이면_예외를_던진다() {
@@ -14,7 +21,50 @@ class BabiesTest {
         List<Baby> babies = new ArrayList<>();
 
         // when & then
-        Assertions.assertThatThrownBy(() -> new Babies(babies))
+        assertThatThrownBy(() -> new Babies(babies))
                 .isInstanceOf(BabiesBadRequestException.class);
+    }
+
+    @Test
+    void 기본_설정된_아기를_조회하는지_확인한다() {
+        // given
+        List<Baby> babyList = new ArrayList<>();
+        babyList.add(new Baby(BABY_ID, BABY_NAME, BIRTHDAY, NOW));
+        Babies babies = new Babies(babyList);
+
+        // when
+        Baby defaultBaby = babies.getDefaultBaby();
+
+        // then
+        assertThat(defaultBaby.getId()).isEqualTo(BABY_ID);
+    }
+
+    @Test
+    void 아기가_한명일때는_기본_설정되지_않은_아기가_존재하지_않는다() {
+        // given
+        List<Baby> babyList = new ArrayList<>();
+        babyList.add(new Baby(BABY_ID, BABY_NAME, BIRTHDAY, NOW));
+        Babies babies = new Babies(babyList);
+
+        // when
+        List<Baby> notDefaultBabies = babies.getNotDefaultBabies();
+
+        // then
+        assertThat(notDefaultBabies.size()).isZero();
+    }
+
+    @Test
+    void 아기가_두명이상일때_기본_설정되지_않은_아기가_존재한다() {
+        // given
+        List<Baby> babyList = new ArrayList<>();
+        babyList.add(new Baby(BABY_ID, BABY_NAME, BIRTHDAY, NOW));
+        babyList.add(new Baby(BABY_ID, BABY_NAME, BIRTHDAY, NOW));
+        Babies babies = new Babies(babyList);
+
+        // when
+        List<Baby> notDefaultBabies = babies.getNotDefaultBabies();
+
+        // then
+        assertThat(notDefaultBabies.size()).isNotZero();
     }
 }

--- a/back/src/test/java/com/baba/back/baby/domain/BabiesTest.java
+++ b/back/src/test/java/com/baba/back/baby/domain/BabiesTest.java
@@ -1,0 +1,20 @@
+package com.baba.back.baby.domain;
+
+import com.baba.back.baby.exception.BabiesBadRequestException;
+import java.util.ArrayList;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class BabiesTest {
+
+    @Test
+    void 아기_리스트의_길이가_0이면_예외를_던진다() {
+        // given
+        List<Baby> babies = new ArrayList<>();
+
+        // when & then
+        Assertions.assertThatThrownBy(() -> new Babies(babies))
+                .isInstanceOf(BabiesBadRequestException.class);
+    }
+}

--- a/back/src/test/java/com/baba/back/baby/service/BabyServiceTest.java
+++ b/back/src/test/java/com/baba/back/baby/service/BabyServiceTest.java
@@ -15,7 +15,6 @@ import com.baba.back.relation.domain.RelationGroup;
 import com.baba.back.relation.exception.RelationNotFoundException;
 import com.baba.back.relation.repository.RelationRepository;
 import java.time.LocalDate;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -43,11 +42,6 @@ class BabyServiceTest {
 
     @Test
     void 멤버가_관계_테이블에_없다면_예외를_던진다() {
-        // given크
-
-        // when
-
-        // then
         assertThatThrownBy(() -> babyService.searchDefaultBaby(MEMBER_ID))
                 .isInstanceOf(RelationNotFoundException.class);
     }
@@ -58,7 +52,7 @@ class BabyServiceTest {
         LocalDate birthday = LocalDate.of(2024, 1, 25);
         LocalDate now = LocalDate.of(2023, 1, 25);
         final String color = "FFAEBA";
-        ColorPicker<String> colorPicker = (List<String> colors) -> color;
+        ColorPicker<String> colorPicker = (colors) -> color;
 
         Member member = memberRepository.save(Member.builder()
                 .id(MEMBER_ID)

--- a/back/src/test/java/com/baba/back/baby/service/BabyServiceTest.java
+++ b/back/src/test/java/com/baba/back/baby/service/BabyServiceTest.java
@@ -41,7 +41,7 @@ class BabyServiceTest {
     private RelationRepository relationRepository;
 
     @Test
-    void 멤버가_관계_테이블에_없다면_예외를_던진다() {
+    void 기본_설정된_아기가_없다면_예외를_던진다() {
         assertThatThrownBy(() -> babyService.searchDefaultBaby(MEMBER_ID))
                 .isInstanceOf(RelationNotFoundException.class);
     }

--- a/back/src/test/java/com/baba/back/baby/service/BabyServiceTest.java
+++ b/back/src/test/java/com/baba/back/baby/service/BabyServiceTest.java
@@ -1,0 +1,91 @@
+package com.baba.back.baby.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.baba.back.baby.domain.Baby;
+import com.baba.back.baby.dto.SearchDefaultBabyResponse;
+import com.baba.back.baby.repository.BabyRepository;
+import com.baba.back.oauth.domain.ColorPicker;
+import com.baba.back.oauth.domain.member.Member;
+import com.baba.back.oauth.repository.MemberRepository;
+import com.baba.back.relation.domain.DefaultRelation;
+import com.baba.back.relation.domain.Relation;
+import com.baba.back.relation.domain.RelationGroup;
+import com.baba.back.relation.exception.RelationNotFoundException;
+import com.baba.back.relation.repository.RelationRepository;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+class BabyServiceTest {
+    public static final String MEMBER_ID = "1234";
+    public static final String BABY_ID = "1234";
+
+    // 디폴트 아기 조회 API에 대한 테스트
+
+    @Autowired
+    private BabyService babyService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private BabyRepository babyRepository;
+
+    @Autowired
+    private RelationRepository relationRepository;
+
+    @Autowired
+    private ColorPicker<String> colorPicker;
+
+    @Test
+    void 멤버가_관계_테이블에_없다면_예외를_던진다() {
+        // given
+
+        // when
+
+        // then
+        assertThatThrownBy(() -> babyService.searchDefaultBaby(MEMBER_ID))
+                .isInstanceOf(RelationNotFoundException.class);
+    }
+
+    @Test
+    void 디폴트_아기를_조회한다() {
+        // given
+        LocalDate birthday = LocalDate.of(2024, 1, 25);
+        LocalDate now = LocalDate.of(2023, 1, 25);
+        Member member = memberRepository.save(Member.builder()
+                .id(MEMBER_ID)
+                .name("박재희")
+                .introduction("")
+                .colorPicker(colorPicker)
+                .iconName("icon1")
+                .build());
+
+        Baby baby = babyRepository.save(Baby.builder()
+                .id(BABY_ID)
+                .name("앙쥬")
+                .birthday(birthday)
+                .now(now)
+                .build());
+
+        relationRepository.save(Relation.builder()
+                .member(member)
+                .baby(baby)
+                .relationName("엄마")
+                .relationGroup(RelationGroup.FAMILY)
+                .defaultRelation(DefaultRelation.DEFAULT)
+                .build());
+
+        // when
+        SearchDefaultBabyResponse response = babyService.searchDefaultBaby(MEMBER_ID);
+
+        // then
+        assertThat(response.getBabyId()).isEqualTo(BABY_ID);
+    }
+}

--- a/back/src/test/java/com/baba/back/baby/service/BabyServiceTest.java
+++ b/back/src/test/java/com/baba/back/baby/service/BabyServiceTest.java
@@ -9,7 +9,6 @@ import com.baba.back.baby.repository.BabyRepository;
 import com.baba.back.oauth.domain.ColorPicker;
 import com.baba.back.oauth.domain.member.Member;
 import com.baba.back.oauth.repository.MemberRepository;
-import com.baba.back.relation.domain.DefaultRelation;
 import com.baba.back.relation.domain.Relation;
 import com.baba.back.relation.domain.RelationGroup;
 import com.baba.back.relation.exception.RelationNotFoundException;
@@ -74,7 +73,7 @@ class BabyServiceTest {
                 .baby(baby)
                 .relationName("엄마")
                 .relationGroup(RelationGroup.FAMILY)
-                .defaultRelation(DefaultRelation.DEFAULT)
+                .defaultRelation(true)
                 .build());
 
         // when

--- a/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
@@ -12,6 +12,7 @@ import com.baba.back.oauth.exception.JoinedMemberBadRequestException;
 import com.baba.back.oauth.exception.JoinedMemberNotFoundException;
 import com.baba.back.oauth.repository.JoinedMemberRepository;
 import com.baba.back.oauth.repository.MemberRepository;
+import com.baba.back.relation.domain.DefaultRelation;
 import com.baba.back.relation.domain.Relation;
 import com.baba.back.relation.repository.RelationRepository;
 import jakarta.transaction.Transactional;
@@ -76,14 +77,15 @@ class MemberServiceTest {
         // when
         final MemberJoinResponse response = memberService.join(request, memberId);
 
-        // then
         final Member member = memberRepository.findById(memberId).orElseThrow();
         final List<Relation> relations = relationRepository.findAllByMember(member);
 
+        // then
         assertAll(
                 () -> assertThat(response.getSignedUp()).isTrue(),
                 () -> assertThat(response.getMessage()).isNotBlank(),
-                () -> assertThat(relations).hasSize(2)
+                () -> assertThat(relations.get(0).getDefaultRelation()).isEqualTo(DefaultRelation.DEFAULT),
+                () -> assertThat(relations.get(1).getDefaultRelation()).isEqualTo(DefaultRelation.NOT_DEFAULT)
         );
     }
 }

--- a/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
@@ -83,8 +83,8 @@ class MemberServiceTest {
         assertAll(
                 () -> assertThat(response.getSignedUp()).isTrue(),
                 () -> assertThat(response.getMessage()).isNotBlank(),
-                () -> assertThat(relations.get(0).isDefaultRelation()).isEqualTo(true),
-                () -> assertThat(relations.get(1).isDefaultRelation()).isEqualTo(false)
+                () -> assertThat(relations.get(0).isDefaultRelation()).isTrue(),
+                () -> assertThat(relations.get(1).isDefaultRelation()).isFalse()
         );
     }
 }

--- a/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
@@ -12,7 +12,6 @@ import com.baba.back.oauth.exception.JoinedMemberBadRequestException;
 import com.baba.back.oauth.exception.JoinedMemberNotFoundException;
 import com.baba.back.oauth.repository.JoinedMemberRepository;
 import com.baba.back.oauth.repository.MemberRepository;
-import com.baba.back.relation.domain.DefaultRelation;
 import com.baba.back.relation.domain.Relation;
 import com.baba.back.relation.repository.RelationRepository;
 import jakarta.transaction.Transactional;
@@ -84,8 +83,8 @@ class MemberServiceTest {
         assertAll(
                 () -> assertThat(response.getSignedUp()).isTrue(),
                 () -> assertThat(response.getMessage()).isNotBlank(),
-                () -> assertThat(relations.get(0).getDefaultRelation()).isEqualTo(DefaultRelation.DEFAULT),
-                () -> assertThat(relations.get(1).getDefaultRelation()).isEqualTo(DefaultRelation.NOT_DEFAULT)
+                () -> assertThat(relations.get(0).isDefaultRelation()).isEqualTo(true),
+                () -> assertThat(relations.get(1).isDefaultRelation()).isEqualTo(false)
         );
     }
 }


### PR DESCRIPTION
## 상세 내용
디폴트 아기 조회 API를 구현하였습니다.
1. Relation 클래스에 디폴트 관계를 나타내는 Enum 타입 필드를 추가하였습니다.
1.1 관련 로직인 `MemberService`의 `saveRelation` 메소드를 첫 번째 아기는 디폴트 관계로, 나머지 아기들은 디폴트가 아닌 관계로 저장하도록 변경하였습니다.

2. 아기를 생성할 때 ID를 주입받을 수 있도록 변경하였습니다.
2.1 `IdConstructor` 인터페이스로 ID를 만들 수 있도록 하여 ID 저장 방식을 바꿀 수 있도록 하였습니다.
2.2 `UUIDConstructor` 구현체를 만들었습니다.
2.3 다만 아기 ID 저장 방식이 UUID에서 다른 것으로 바뀔지가 의문입니다.

3. `BabyService`와 `BabyController`를 구현하였습니다.

Close #10  
