### PR TITLE
ci: jdk distribution 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '17'
+          distribution: 'temurin'
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
         working-directory: ./back


### PR DESCRIPTION
## 상세 내용
 setup-java단계에서 Eclipse Adoptium에서 Eclipse Temurin(Java) 17 JDK를 구성하도록 설정하였습니다.
[참고](https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle)


Close #27
