### PR TITLE
성장 앨범 추가 API를 수정한다.

### DIFF
--- a/back/src/main/java/com/baba/back/common/domain/BaseEntity.java
+++ b/back/src/main/java/com/baba/back/common/domain/BaseEntity.java
@@ -15,10 +15,10 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public class BaseEntity {
 
     @CreatedDate
-    private LocalDateTime createdDate;
+    private LocalDateTime createdAt;
 
     @LastModifiedDate
-    private LocalDateTime updatedDate;
+    private LocalDateTime updatedAt;
 
     private boolean deleted = false;
 

--- a/back/src/main/java/com/baba/back/common/domain/BaseEntity.java
+++ b/back/src/main/java/com/baba/back/common/domain/BaseEntity.java
@@ -12,7 +12,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-public class BaseEntity {
+public abstract class BaseEntity {
 
     @CreatedDate
     private LocalDateTime createdAt;

--- a/back/src/main/java/com/baba/back/content/domain/content/Content.java
+++ b/back/src/main/java/com/baba/back/content/domain/content/Content.java
@@ -38,16 +38,16 @@ public class Content {
     private Baby baby;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private Member member;
+    private Member owner;
 
     @Builder
-    public Content(String title, LocalDate contentDate, LocalDate now, String cardStyle, Baby baby, Member member) {
+    public Content(String title, LocalDate contentDate, LocalDate now, String cardStyle, Baby baby, Member owner) {
         this.title = new Title(title);
         this.contentDate = ContentDate.of(contentDate, now, baby.getBirthday());
         this.cardStyle = new CardStyle(cardStyle);
         this.imageSource = new ImageSource("");
         this.baby = baby;
-        this.member = member;
+        this.owner = owner;
     }
 
     public void updateURL(String imageSource) {

--- a/back/src/main/java/com/baba/back/content/domain/content/Content.java
+++ b/back/src/main/java/com/baba/back/content/domain/content/Content.java
@@ -1,6 +1,7 @@
 package com.baba.back.content.domain.content;
 
 import com.baba.back.baby.domain.Baby;
+import com.baba.back.oauth.domain.member.Member;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -36,13 +37,17 @@ public class Content {
     @ManyToOne(fetch = FetchType.LAZY)
     private Baby baby;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
     @Builder
-    public Content(String title, LocalDate contentDate, LocalDate now, String cardStyle, Baby baby) {
+    public Content(String title, LocalDate contentDate, LocalDate now, String cardStyle, Baby baby, Member member) {
         this.title = new Title(title);
         this.contentDate = ContentDate.of(contentDate, now, baby.getBirthday());
         this.cardStyle = new CardStyle(cardStyle);
         this.imageSource = new ImageSource("");
         this.baby = baby;
+        this.member = member;
     }
 
     public void updateURL(String imageSource) {

--- a/back/src/main/java/com/baba/back/content/exception/ContentBadRequestException.java
+++ b/back/src/main/java/com/baba/back/content/exception/ContentBadRequestException.java
@@ -1,0 +1,10 @@
+package com.baba.back.content.exception;
+
+import com.baba.back.exception.BadRequestException;
+
+public class ContentBadRequestException extends BadRequestException {
+
+    public ContentBadRequestException(String message) {
+        super(message);
+    }
+}

--- a/back/src/main/java/com/baba/back/content/repository/ContentRepository.java
+++ b/back/src/main/java/com/baba/back/content/repository/ContentRepository.java
@@ -3,9 +3,8 @@ package com.baba.back.content.repository;
 import com.baba.back.baby.domain.Baby;
 import com.baba.back.content.domain.content.Content;
 import com.baba.back.content.domain.content.ContentDate;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ContentRepository extends JpaRepository<Content, Long> {
-    Optional<Content> findByContentDateAndBaby(ContentDate contentDate, Baby baby);
+    boolean existsByContentDateAndBaby(ContentDate contentDate, Baby baby);
 }

--- a/back/src/main/java/com/baba/back/content/repository/ContentRepository.java
+++ b/back/src/main/java/com/baba/back/content/repository/ContentRepository.java
@@ -1,7 +1,11 @@
 package com.baba.back.content.repository;
 
+import com.baba.back.baby.domain.Baby;
 import com.baba.back.content.domain.content.Content;
+import com.baba.back.content.domain.content.ContentDate;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ContentRepository extends JpaRepository<Content, Long> {
+    Optional<Content> findByContentDateAndBaby(ContentDate contentDate, Baby baby);
 }

--- a/back/src/main/java/com/baba/back/content/service/ContentService.java
+++ b/back/src/main/java/com/baba/back/content/service/ContentService.java
@@ -88,9 +88,9 @@ public class ContentService {
     }
 
     private void checkDuplication(ContentDate contentDate, Baby baby) {
-        contentRepository.findByContentDateAndBaby(contentDate, baby).ifPresent(content -> {
+        if(contentRepository.existsByContentDateAndBaby(contentDate, baby)) {
             throw new ContentBadRequestException("컨텐츠가 이미 존재합니다.");
-        });
+        }
     }
 
     public LikeContentResponse likeContent(String memberId, String babyId, Long contentId) {

--- a/back/src/main/java/com/baba/back/content/service/ContentService.java
+++ b/back/src/main/java/com/baba/back/content/service/ContentService.java
@@ -52,6 +52,7 @@ public class ContentService {
                 .now(LocalDate.now())
                 .cardStyle(request.getCardStyle())
                 .baby(baby)
+                .member(member)
                 .build();
 
         checkDuplication(content.getContentDate(), baby);

--- a/back/src/main/java/com/baba/back/content/service/ContentService.java
+++ b/back/src/main/java/com/baba/back/content/service/ContentService.java
@@ -52,7 +52,7 @@ public class ContentService {
                 .now(LocalDate.now())
                 .cardStyle(request.getCardStyle())
                 .baby(baby)
-                .member(member)
+                .owner(member)
                 .build();
 
         checkDuplication(content.getContentDate(), baby);

--- a/back/src/main/java/com/baba/back/content/service/ContentService.java
+++ b/back/src/main/java/com/baba/back/content/service/ContentService.java
@@ -7,10 +7,12 @@ import com.baba.back.content.domain.FileHandler;
 import com.baba.back.content.domain.ImageFile;
 import com.baba.back.content.domain.Like;
 import com.baba.back.content.domain.content.Content;
+import com.baba.back.content.domain.content.ContentDate;
 import com.baba.back.content.dto.CreateContentRequest;
 import com.baba.back.content.dto.CreateContentResponse;
 import com.baba.back.content.dto.LikeContentResponse;
 import com.baba.back.content.exception.ContentAuthorizationException;
+import com.baba.back.content.exception.ContentBadRequestException;
 import com.baba.back.content.exception.ContentNotFountException;
 import com.baba.back.content.repository.ContentRepository;
 import com.baba.back.content.repository.LikeRepository;
@@ -51,6 +53,9 @@ public class ContentService {
                 .cardStyle(request.getCardStyle())
                 .baby(baby)
                 .build();
+
+        checkDuplication(content.getContentDate(), baby);
+
         final ImageFile imageFile = new ImageFile(request.getPhoto());
         final String imageSource = fileHandler.upload(imageFile);
         content.updateURL(imageSource);
@@ -79,6 +84,12 @@ public class ContentService {
         if (!relation.isFamily()) {
             throw new ContentAuthorizationException(relation.getId() + " 관계는 가족 관계가 아닙니다.");
         }
+    }
+
+    private void checkDuplication(ContentDate contentDate, Baby baby) {
+        contentRepository.findByContentDateAndBaby(contentDate, baby).ifPresent(content -> {
+            throw new ContentBadRequestException("컨텐츠가 이미 존재합니다.");
+        });
     }
 
     public LikeContentResponse likeContent(String memberId, String babyId, Long contentId) {

--- a/back/src/test/java/com/baba/back/common/domain/BaseEntityTest.java
+++ b/back/src/test/java/com/baba/back/common/domain/BaseEntityTest.java
@@ -1,11 +1,19 @@
 package com.baba.back.common.domain;
 
 import static com.baba.back.fixture.DomainFixture.멤버1;
+import static com.baba.back.fixture.DomainFixture.아기1;
 import static com.baba.back.fixture.DomainFixture.컨텐츠;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.baba.back.baby.domain.Baby;
+import com.baba.back.baby.repository.BabyRepository;
 import com.baba.back.content.domain.Like;
+import com.baba.back.content.domain.content.Content;
+import com.baba.back.content.repository.ContentRepository;
 import com.baba.back.content.repository.LikeRepository;
+import com.baba.back.oauth.domain.member.Member;
+import com.baba.back.oauth.repository.MemberRepository;
+import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -14,19 +22,30 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 class BaseEntityTest {
 
     @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private BabyRepository babyRepository;
+
+    @Autowired
+    private ContentRepository contentRepository;
+
+    @Autowired
     private LikeRepository likeRepository;
 
     @Test
     void 생성시간과_업데이트시간을_확인한다() {
         // given
-        final Like like = Like.builder()
-                .member(멤버1)
-                .content(컨텐츠)
-                .build();
+        final LocalDate now = LocalDate.now();
+        final Member savedMember = memberRepository.save(멤버1);
+        final Baby savedBaby = babyRepository.save(아기1);
+        final Content savedContent = contentRepository.save(
+                new Content("제목", now, now, "card_basic_1", savedBaby, savedMember));
 
-        likeRepository.save(like);
+        // when
+        final Like like = likeRepository.save(new Like(savedMember, savedContent));
 
-        // when & then
+        // then
         assertThat(like.getCreatedDate()).isNotNull();
         assertThat(like.getUpdatedDate()).isNotNull();
     }

--- a/back/src/test/java/com/baba/back/common/domain/BaseEntityTest.java
+++ b/back/src/test/java/com/baba/back/common/domain/BaseEntityTest.java
@@ -46,8 +46,8 @@ class BaseEntityTest {
         final Like like = likeRepository.save(new Like(savedMember, savedContent));
 
         // then
-        assertThat(like.getCreatedDate()).isNotNull();
-        assertThat(like.getUpdatedDate()).isNotNull();
+        assertThat(like.getCreatedAt()).isNotNull();
+        assertThat(like.getUpdatedAt()).isNotNull();
     }
 
     @Test

--- a/back/src/test/java/com/baba/back/content/domain/LikeTest.java
+++ b/back/src/test/java/com/baba/back/content/domain/LikeTest.java
@@ -13,6 +13,8 @@ import com.baba.back.content.repository.LikeRepository;
 import com.baba.back.oauth.domain.member.Member;
 import com.baba.back.oauth.repository.MemberRepository;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -34,18 +36,21 @@ class LikeTest {
     @Test
     void 생성시간과_업데이트시간을_확인한다() {
         // given
-        final LocalDate now = LocalDate.now();
+        final LocalDateTime now = LocalDateTime.now();
+        final LocalDate today = now.toLocalDate();
         final Member savedMember = memberRepository.save(멤버1);
         final Baby savedBaby = babyRepository.save(아기1);
         final Content savedContent = contentRepository.save(
-                new Content("제목", now, now, "card_basic_1", savedBaby, savedMember));
+                new Content("제목", today, today, "card_basic_1", savedBaby, savedMember));
 
         // when
         final Like like = likeRepository.save(new Like(savedMember, savedContent));
 
         // then
-        assertThat(like.getCreatedAt()).isNotNull();
-        assertThat(like.getUpdatedAt()).isNotNull();
+        Assertions.assertAll(
+                () -> assertThat(like.getCreatedAt()).isAfter(now),
+                () -> assertThat(like.getUpdatedAt()).isAfter(now)
+        );
     }
 
     @Test

--- a/back/src/test/java/com/baba/back/content/domain/LikeTest.java
+++ b/back/src/test/java/com/baba/back/content/domain/LikeTest.java
@@ -1,4 +1,4 @@
-package com.baba.back.common.domain;
+package com.baba.back.content.domain;
 
 import static com.baba.back.fixture.DomainFixture.멤버1;
 import static com.baba.back.fixture.DomainFixture.아기1;
@@ -7,7 +7,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.baba.back.baby.domain.Baby;
 import com.baba.back.baby.repository.BabyRepository;
-import com.baba.back.content.domain.Like;
 import com.baba.back.content.domain.content.Content;
 import com.baba.back.content.repository.ContentRepository;
 import com.baba.back.content.repository.LikeRepository;
@@ -19,8 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 @DataJpaTest
-class BaseEntityTest {
-
+class LikeTest {
     @Autowired
     private MemberRepository memberRepository;
 

--- a/back/src/test/java/com/baba/back/content/repository/ContentRepositoryTest.java
+++ b/back/src/test/java/com/baba/back/content/repository/ContentRepositoryTest.java
@@ -6,7 +6,6 @@ import static com.baba.back.fixture.DomainFixture.컨텐츠;
 
 import com.baba.back.baby.domain.Baby;
 import com.baba.back.baby.repository.BabyRepository;
-import com.baba.back.content.domain.content.Content;
 import com.baba.back.oauth.repository.MemberRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -26,17 +25,29 @@ class ContentRepositoryTest {
     private ContentRepository contentRepository;
 
     @Test
-    void 날짜와_아기로_컨텐츠를_조회할_수_있다() {
+    void 해당_날짜에_이미_컨텐츠를_추가했다() {
         // given
         memberRepository.save(멤버1);
         final Baby baby = babyRepository.save(아기1);
-        final Content savedContent = contentRepository.save(컨텐츠);
+        contentRepository.save(컨텐츠);
 
         // when
-        final Content foundContent = contentRepository.findByContentDateAndBaby(savedContent.getContentDate(), baby)
-                .orElseThrow();
+        final boolean exists = contentRepository.existsByContentDateAndBaby(컨텐츠.getContentDate(), baby);
 
         // then
-        Assertions.assertThat(foundContent).isEqualTo(savedContent);
+        Assertions.assertThat(exists).isTrue();
+    }
+
+    @Test
+    void 해당_날짜에_아직_컨텐츠가_없다() {
+        // given
+        memberRepository.save(멤버1);
+        final Baby baby = babyRepository.save(아기1);
+
+        // when
+        final boolean exists = contentRepository.existsByContentDateAndBaby(컨텐츠.getContentDate(), baby);
+
+        // then
+        Assertions.assertThat(exists).isFalse();
     }
 }

--- a/back/src/test/java/com/baba/back/content/repository/ContentRepositoryTest.java
+++ b/back/src/test/java/com/baba/back/content/repository/ContentRepositoryTest.java
@@ -1,0 +1,35 @@
+package com.baba.back.content.repository;
+
+import static com.baba.back.fixture.DomainFixture.아기1;
+import static com.baba.back.fixture.DomainFixture.컨텐츠;
+
+import com.baba.back.baby.domain.Baby;
+import com.baba.back.baby.repository.BabyRepository;
+import com.baba.back.content.domain.content.Content;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class ContentRepositoryTest {
+    @Autowired
+    private BabyRepository babyRepository;
+
+    @Autowired
+    private ContentRepository contentRepository;
+
+    @Test
+    void 날짜와_아기로_컨텐츠를_조회할_수_있다() {
+        // given
+        final Baby baby = babyRepository.save(아기1);
+        final Content savedContent = contentRepository.save(컨텐츠);
+
+        // when
+        final Content foundContent = contentRepository.findByContentDateAndBaby(savedContent.getContentDate(), baby)
+                .orElseThrow();
+
+        // then
+        Assertions.assertThat(foundContent).isEqualTo(savedContent);
+    }
+}

--- a/back/src/test/java/com/baba/back/content/repository/ContentRepositoryTest.java
+++ b/back/src/test/java/com/baba/back/content/repository/ContentRepositoryTest.java
@@ -1,11 +1,13 @@
 package com.baba.back.content.repository;
 
+import static com.baba.back.fixture.DomainFixture.멤버1;
 import static com.baba.back.fixture.DomainFixture.아기1;
 import static com.baba.back.fixture.DomainFixture.컨텐츠;
 
 import com.baba.back.baby.domain.Baby;
 import com.baba.back.baby.repository.BabyRepository;
 import com.baba.back.content.domain.content.Content;
+import com.baba.back.oauth.repository.MemberRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +15,10 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 @DataJpaTest
 class ContentRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
     @Autowired
     private BabyRepository babyRepository;
 
@@ -22,6 +28,7 @@ class ContentRepositoryTest {
     @Test
     void 날짜와_아기로_컨텐츠를_조회할_수_있다() {
         // given
+        memberRepository.save(멤버1);
         final Baby baby = babyRepository.save(아기1);
         final Content savedContent = contentRepository.save(컨텐츠);
 

--- a/back/src/test/java/com/baba/back/content/repository/LikeRepositoryTest.java
+++ b/back/src/test/java/com/baba/back/content/repository/LikeRepositoryTest.java
@@ -2,15 +2,15 @@ package com.baba.back.content.repository;
 
 import static com.baba.back.fixture.DomainFixture.멤버1;
 import static com.baba.back.fixture.DomainFixture.아기1;
-import static com.baba.back.fixture.DomainFixture.좋아요;
-import static com.baba.back.fixture.DomainFixture.컨텐츠;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.baba.back.baby.domain.Baby;
 import com.baba.back.baby.repository.BabyRepository;
 import com.baba.back.content.domain.Like;
 import com.baba.back.content.domain.content.Content;
 import com.baba.back.oauth.domain.member.Member;
 import com.baba.back.oauth.repository.MemberRepository;
+import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -33,13 +33,15 @@ class LikeRepositoryTest {
     @Test
     void 멤버와_컨텐츠로_좋아요를_조회한다() {
         // given
-        final Member member = memberRepository.save(멤버1);
-        babyRepository.save(아기1);
-        final Content content = contentRepository.save(컨텐츠);
-        final Like savedLike = likeRepository.save(좋아요);
+        final LocalDate now = LocalDate.now();
+        final Member savedMember = memberRepository.save(멤버1);
+        final Baby savedBaby = babyRepository.save(아기1);
+        final Content savedContent = contentRepository.save(
+                new Content("제목", now, now, "card_basic_1", savedBaby, savedMember));
+        final Like savedLike = likeRepository.save(new Like(savedMember, savedContent));
 
         // when
-        final Like findLike = likeRepository.findByMemberAndContent(member, content).orElseThrow();
+        final Like findLike = likeRepository.findByMemberAndContent(savedMember, savedContent).orElseThrow();
 
         // then
         assertThat(savedLike).isEqualTo(findLike);

--- a/back/src/test/java/com/baba/back/content/service/ContentServiceTest.java
+++ b/back/src/test/java/com/baba/back/content/service/ContentServiceTest.java
@@ -116,7 +116,7 @@ class ContentServiceTest {
         given(memberRepository.findById(any())).willReturn(Optional.of(멤버1));
         given(babyRepository.findById(any())).willReturn(Optional.of(아기1));
         given(relationRepository.findByMemberAndBaby(any(), any())).willReturn(Optional.of(관계1));
-        given(contentRepository.findByContentDateAndBaby(any(), any())).willReturn(Optional.of(컨텐츠));
+        given(contentRepository.existsByContentDateAndBaby(any(), any())).willReturn(true);
 
         // when & then
         Assertions.assertThatThrownBy(() -> contentService.createContent(컨텐츠_생성_요청, MEMBER_ID, BABY_ID))
@@ -129,6 +129,7 @@ class ContentServiceTest {
         given(memberRepository.findById(any())).willReturn(Optional.of(멤버1));
         given(babyRepository.findById(any())).willReturn(Optional.of(아기1));
         given(relationRepository.findByMemberAndBaby(any(), any())).willReturn(Optional.of(관계1));
+        given(contentRepository.existsByContentDateAndBaby(any(), any())).willReturn(false);
         given(fileHandler.upload(any())).willReturn("VALID_IMAGE_SOURCE");
 
         // when

--- a/back/src/test/java/com/baba/back/content/service/ContentServiceTest.java
+++ b/back/src/test/java/com/baba/back/content/service/ContentServiceTest.java
@@ -21,6 +21,7 @@ import com.baba.back.content.domain.FileHandler;
 import com.baba.back.content.dto.CreateContentResponse;
 import com.baba.back.content.dto.LikeContentResponse;
 import com.baba.back.content.exception.ContentAuthorizationException;
+import com.baba.back.content.exception.ContentBadRequestException;
 import com.baba.back.content.exception.ContentNotFountException;
 import com.baba.back.content.repository.ContentRepository;
 import com.baba.back.content.repository.LikeRepository;
@@ -107,6 +108,19 @@ class ContentServiceTest {
         // when & then
         Assertions.assertThatThrownBy(() -> contentService.createContent(컨텐츠_생성_요청, MEMBER_ID, BABY_ID))
                 .isInstanceOf(ContentAuthorizationException.class);
+    }
+
+    @Test
+    void 해당_날짜에_이미_컨텐츠가_존재하면_예외를_던진다() {
+        // given
+        given(memberRepository.findById(any())).willReturn(Optional.of(멤버1));
+        given(babyRepository.findById(any())).willReturn(Optional.of(아기1));
+        given(relationRepository.findByMemberAndBaby(any(), any())).willReturn(Optional.of(관계1));
+        given(contentRepository.findByContentDateAndBaby(any(), any())).willReturn(Optional.of(컨텐츠));
+
+        // when & then
+        Assertions.assertThatThrownBy(() -> contentService.createContent(컨텐츠_생성_요청, MEMBER_ID, BABY_ID))
+                .isInstanceOf(ContentBadRequestException.class);
     }
 
     @Test

--- a/back/src/test/java/com/baba/back/fixture/DomainFixture.java
+++ b/back/src/test/java/com/baba/back/fixture/DomainFixture.java
@@ -55,7 +55,7 @@ public class DomainFixture {
             .now(LocalDate.now())
             .cardStyle("card_basic_1")
             .baby(아기1)
-            .member(멤버1)
+            .owner(멤버1)
             .build();
 
     public static final Like 좋아요 = Like.builder()

--- a/back/src/test/java/com/baba/back/fixture/DomainFixture.java
+++ b/back/src/test/java/com/baba/back/fixture/DomainFixture.java
@@ -55,6 +55,7 @@ public class DomainFixture {
             .now(LocalDate.now())
             .cardStyle("card_basic_1")
             .baby(아기1)
+            .member(멤버1)
             .build();
 
     public static final Like 좋아요 = Like.builder()


### PR DESCRIPTION
## 상세 내용
- 컨텐츠를 누가 생성했는지 조회해야 하므로 `Content` 엔티티에 `member` 필드를 추가했습니다.
- 같은 날짜에 컨텐츠를 두 번 올릴 수 없게 변경하였습니다.

Close #31 
