### PR TITLE
사용자 정보 조회 API 를 구현한다

### DIFF
--- a/back/src/main/java/com/baba/back/oauth/controller/MemberController.java
+++ b/back/src/main/java/com/baba/back/oauth/controller/MemberController.java
@@ -44,6 +44,7 @@ public class MemberController {
 
     @Operation(summary = "멤버 정보 조회 요청")
     @OkResponse
+    @UnAuthorizedResponse
     @NotFoundResponse
     @IntervalServerErrorResponse
     @GetMapping("/members")

--- a/back/src/main/java/com/baba/back/oauth/controller/MemberController.java
+++ b/back/src/main/java/com/baba/back/oauth/controller/MemberController.java
@@ -1,13 +1,16 @@
 package com.baba.back.oauth.controller;
 
+import com.baba.back.oauth.dto.MemberResponse;
 import com.baba.back.oauth.dto.MemberSignUpRequest;
 import com.baba.back.oauth.dto.MemberSignUpResponse;
 import com.baba.back.oauth.service.MemberService;
+import com.baba.back.oauth.support.Login;
 import com.baba.back.oauth.support.SignUp;
 import com.baba.back.swagger.BadRequestResponse;
 import com.baba.back.swagger.CreatedResponse;
 import com.baba.back.swagger.IntervalServerErrorResponse;
 import com.baba.back.swagger.NotFoundResponse;
+import com.baba.back.swagger.OkResponse;
 import com.baba.back.swagger.UnAuthorizedResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -15,6 +18,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -36,5 +40,14 @@ public class MemberController {
     public ResponseEntity<MemberSignUpResponse> joinMember(@RequestBody @Valid MemberSignUpRequest request,
                                                            @SignUp String memberId) {
         return ResponseEntity.status(HttpStatus.CREATED).body(memberService.signUp(request, memberId));
+    }
+
+    @Operation(summary = "멤버 정보 조회 요청")
+    @OkResponse
+    @NotFoundResponse
+    @IntervalServerErrorResponse
+    @GetMapping("/members")
+    public ResponseEntity<MemberResponse> findMember(@Login String memberId) {
+        return ResponseEntity.ok(memberService.findMember(memberId));
     }
 }

--- a/back/src/main/java/com/baba/back/oauth/domain/member/Icon.java
+++ b/back/src/main/java/com/baba/back/oauth/domain/member/Icon.java
@@ -2,6 +2,7 @@ package com.baba.back.oauth.domain.member;
 
 import com.baba.back.oauth.domain.Picker;
 import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -14,13 +15,21 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Icon {
 
-    @Enumerated
+    @Enumerated(EnumType.STRING)
     private IconColor iconColor;
 
-    @Enumerated
+    @Enumerated(EnumType.STRING)
     private IconName iconName;
 
     public static Icon of(Picker<IconColor> picker, String iconName) {
         return new Icon(IconColor.from(picker), IconName.from(iconName));
+    }
+
+    public String getIconColor() {
+        return this.iconColor.name();
+    }
+
+    public String getIconName() {
+        return this.iconName.name();
     }
 }

--- a/back/src/main/java/com/baba/back/oauth/domain/member/IconColor.java
+++ b/back/src/main/java/com/baba/back/oauth/domain/member/IconColor.java
@@ -4,20 +4,18 @@ import com.baba.back.oauth.domain.Picker;
 import com.baba.back.oauth.exception.IconColorBadRequestException;
 import java.util.Arrays;
 import java.util.List;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-@Getter
 @RequiredArgsConstructor
 public enum IconColor {
     COLOR_1("FFAEBA"), COLOR_2("FF8698"), COLOR_3("FFE3C8"), COLOR_4("FFD2A7"), COLOR_5("FFD400"), COLOR_6("9ED883"),
     COLOR_7("30BE9B"), COLOR_8("81E0D5"), COLOR_9("5BD2FF"), COLOR_10("97BEFF"), COLOR_11("98A2FF"), COLOR_12("BFA1FF");
 
-    private final String color;
+    private final String value;
 
     public static IconColor from(String color) {
         return Arrays.stream(IconColor.values())
-                .filter(iconColor -> iconColor.getColor().equals(color))
+                .filter(iconColor -> iconColor.value.equals(color))
                 .findAny()
                 .orElseThrow(() -> new IconColorBadRequestException(color + " 는 잘못된 IconColor 입니다."));
     }

--- a/back/src/main/java/com/baba/back/oauth/domain/member/Introduction.java
+++ b/back/src/main/java/com/baba/back/oauth/domain/member/Introduction.java
@@ -1,6 +1,7 @@
 package com.baba.back.oauth.domain.member;
 
 import com.baba.back.oauth.exception.IntroductionLengthBadRequestException;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.util.Objects;
 import lombok.Getter;
@@ -12,12 +13,13 @@ import lombok.NoArgsConstructor;
 public class Introduction {
     public static final int INTRODUCTION_MAX_LENGTH = 100;
 
-    private String introduction;
+    @Column(name = "introduction")
+    private String value;
 
-    public Introduction(String introduction) {
-        validNull(introduction);
-        validLength(introduction);
-        this.introduction = introduction;
+    public Introduction(String value) {
+        validNull(value);
+        validLength(value);
+        this.value = value;
     }
 
     private void validNull(String introduction) {

--- a/back/src/main/java/com/baba/back/oauth/domain/member/Member.java
+++ b/back/src/main/java/com/baba/back/oauth/domain/member/Member.java
@@ -32,4 +32,20 @@ public class Member {
         this.introduction = new Introduction(introduction);
         this.icon = Icon.of(colorPicker, iconName);
     }
+
+    public String getName() {
+        return this.name.getValue();
+    }
+
+    public String getIntroduction() {
+        return this.introduction.getValue();
+    }
+
+    public String getIconColor() {
+        return this.icon.getIconColor();
+    }
+
+    public String getIconName() {
+        return this.icon.getIconName();
+    }
 }

--- a/back/src/main/java/com/baba/back/oauth/domain/member/Name.java
+++ b/back/src/main/java/com/baba/back/oauth/domain/member/Name.java
@@ -1,6 +1,7 @@
 package com.baba.back.oauth.domain.member;
 
 import com.baba.back.oauth.exception.NameLengthBadRequestException;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.util.Objects;
 import lombok.Getter;
@@ -12,12 +13,13 @@ import lombok.NoArgsConstructor;
 public class Name {
     public static final int NAME_MAX_LENGTH = 6;
 
-    private String name;
+    @Column(name = "name")
+    private String value;
 
-    public Name(String name) {
-        validNull(name);
-        validName(name);
-        this.name = name;
+    public Name(String value) {
+        validNull(value);
+        validName(value);
+        this.value = value;
     }
 
     private void validNull(String name) {

--- a/back/src/main/java/com/baba/back/oauth/dto/LoginTokenResponse.java
+++ b/back/src/main/java/com/baba/back/oauth/dto/LoginTokenResponse.java
@@ -1,5 +1,5 @@
 package com.baba.back.oauth.dto;
 
-public record LoginTokenResponse(String accessToken, String refreshToken) implements TokenResponse{
+public record LoginTokenResponse(String accessToken, String refreshToken) implements TokenResponse {
 
 }

--- a/back/src/main/java/com/baba/back/oauth/dto/MemberResponse.java
+++ b/back/src/main/java/com/baba/back/oauth/dto/MemberResponse.java
@@ -1,0 +1,4 @@
+package com.baba.back.oauth.dto;
+
+public record MemberResponse(String name, String introduction, String iconName, String iconColor) {
+}

--- a/back/src/main/java/com/baba/back/oauth/dto/SignTokenResponse.java
+++ b/back/src/main/java/com/baba/back/oauth/dto/SignTokenResponse.java
@@ -1,4 +1,4 @@
 package com.baba.back.oauth.dto;
 
-public record SignTokenResponse(String signToken) implements TokenResponse{
+public record SignTokenResponse(String signToken) implements TokenResponse {
 }

--- a/back/src/main/java/com/baba/back/oauth/service/MemberService.java
+++ b/back/src/main/java/com/baba/back/oauth/service/MemberService.java
@@ -6,9 +6,11 @@ import com.baba.back.baby.repository.BabyRepository;
 import com.baba.back.oauth.domain.Picker;
 import com.baba.back.oauth.domain.member.IconColor;
 import com.baba.back.oauth.domain.member.Member;
+import com.baba.back.oauth.dto.MemberResponse;
 import com.baba.back.oauth.dto.MemberSignUpRequest;
 import com.baba.back.oauth.dto.MemberSignUpResponse;
 import com.baba.back.oauth.exception.MemberBadRequestException;
+import com.baba.back.oauth.exception.MemberNotFoundException;
 import com.baba.back.oauth.repository.MemberRepository;
 import com.baba.back.relation.domain.Relation;
 import com.baba.back.relation.domain.RelationGroup;
@@ -79,5 +81,17 @@ public class MemberService {
                         .relationGroup(RelationGroup.FAMILY)
                         .build())
                 .forEach(relationRepository::save);
+    }
+
+    public MemberResponse findMember(String memberId) {
+        final Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(memberId + "에 해당하는 멤버가 존재하지 않습니다."));
+
+        return new MemberResponse(
+                member.getName(),
+                member.getIntroduction(),
+                member.getIconName(),
+                member.getIconColor()
+        );
     }
 }

--- a/back/src/main/java/com/baba/back/oauth/service/SignTokenProvider.java
+++ b/back/src/main/java/com/baba/back/oauth/service/SignTokenProvider.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class SignTokenProvider extends TokenProvider {
     public SignTokenProvider(@Value("${security.jwt.token.sign.secret-key}") String secretKey,
-                                @Value("${security.jwt.token.sign.expire-length}") Long validityInMilliseconds) {
+                             @Value("${security.jwt.token.sign.expire-length}") Long validityInMilliseconds) {
         super(secretKey, validityInMilliseconds);
     }
 }

--- a/back/src/test/java/com/baba/back/oauth/acceptance/MemberAcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/acceptance/MemberAcceptanceTest.java
@@ -1,5 +1,6 @@
 package com.baba.back.oauth.acceptance;
 
+import static com.baba.back.SimpleRestAssured.get;
 import static com.baba.back.SimpleRestAssured.post;
 import static com.baba.back.SimpleRestAssured.toObject;
 import static com.baba.back.fixture.DomainFixture.멤버1;
@@ -11,34 +12,40 @@ import com.baba.back.AcceptanceTest;
 import com.baba.back.SimpleRestAssured;
 import com.baba.back.baby.dto.BabyRequest;
 import com.baba.back.common.dto.ExceptionResponse;
+import com.baba.back.oauth.domain.Picker;
+import com.baba.back.oauth.domain.member.IconColor;
+import com.baba.back.oauth.dto.MemberResponse;
 import com.baba.back.oauth.dto.MemberSignUpRequest;
 import com.baba.back.oauth.dto.MemberSignUpResponse;
-import com.baba.back.oauth.repository.MemberRepository;
+import com.baba.back.oauth.service.AccessTokenProvider;
 import com.baba.back.oauth.service.SignTokenProvider;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpStatus;
 
 class MemberAcceptanceTest extends AcceptanceTest {
 
-    private static final String MEMBER_BASE_PATH = "/api/members/baby";
+    private static final String MEMBER_BASE_PATH = "/api/members";
     private static final String MEMBER_ID = "memberId";
 
     @Autowired
-    private SignTokenProvider tokenProvider;
+    private SignTokenProvider signTokenProvider;
 
     @Autowired
-    private MemberRepository memberRepository;
+    private AccessTokenProvider accessTokenProvider;
 
     @Test
     void 요청에_sign_토큰이_존재하지않으면_400을_응답한다() {
         // given
-        final ExtractableResponse<Response> response = SimpleRestAssured.post(MEMBER_BASE_PATH, 멤버_가입_요청);
+        final ExtractableResponse<Response> response = SimpleRestAssured.post(MEMBER_BASE_PATH + "/baby", 멤버_가입_요청);
 
         // when & then
         assertAll(
@@ -52,7 +59,7 @@ class MemberAcceptanceTest extends AcceptanceTest {
         // given
         final String invalidSignToken = "111";
         final ExtractableResponse<Response> response = post(
-                MEMBER_BASE_PATH, Map.of("Authorization", "Bearer " + invalidSignToken), 멤버_가입_요청
+                MEMBER_BASE_PATH + "/baby", Map.of("Authorization", "Bearer " + invalidSignToken), 멤버_가입_요청
         );
 
         // when & then
@@ -69,9 +76,10 @@ class MemberAcceptanceTest extends AcceptanceTest {
                 List.of(new BabyRequest("아기1", LocalDate.of(2022, 1, 1)),
                         new BabyRequest("아기2", LocalDate.of(2023, 1, 1)))
         );
-        final String validToken = tokenProvider.createToken(MEMBER_ID);
+        final String validToken = signTokenProvider.createToken(MEMBER_ID);
         final ExtractableResponse<Response> response = post(
-                MEMBER_BASE_PATH, Map.of("Authorization", "Bearer " + validToken), INVALID_MEMBER_SIGN_UP_REQUEST
+                MEMBER_BASE_PATH + "/baby", Map.of("Authorization", "Bearer " + validToken),
+                INVALID_MEMBER_SIGN_UP_REQUEST
         );
 
         // when & then
@@ -84,13 +92,13 @@ class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     void 이미_가입한_유저가_회원가입을_요청하면_400을_던진다() {
         // given
-        final String invalidSignToken = tokenProvider.createToken(멤버1.getId());
+        final String invalidSignToken = signTokenProvider.createToken(멤버1.getId());
 
-        post(MEMBER_BASE_PATH, Map.of("Authorization", "Bearer " + invalidSignToken), 멤버_가입_요청);
+        post(MEMBER_BASE_PATH + "/baby", Map.of("Authorization", "Bearer " + invalidSignToken), 멤버_가입_요청);
 
         // when
         final ExtractableResponse<Response> response = post(
-                MEMBER_BASE_PATH, Map.of("Authorization", "Bearer " + invalidSignToken), 멤버_가입_요청
+                MEMBER_BASE_PATH + "/baby", Map.of("Authorization", "Bearer " + invalidSignToken), 멤버_가입_요청
         );
 
         //  then
@@ -103,11 +111,11 @@ class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     void 회원가입을_진행한다() {
         // given
-        final String token = tokenProvider.createToken(MEMBER_ID);
+        final String token = signTokenProvider.createToken(MEMBER_ID);
 
         // when
         final ExtractableResponse<Response> response = post(
-                MEMBER_BASE_PATH, Map.of("Authorization", "Bearer " + token), 멤버_가입_요청
+                MEMBER_BASE_PATH + "/baby", Map.of("Authorization", "Bearer " + token), 멤버_가입_요청
         );
 
         // then
@@ -116,5 +124,45 @@ class MemberAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.as(MemberSignUpResponse.class).accessToken()).isNotBlank(),
                 () -> assertThat(response.as(MemberSignUpResponse.class).refreshToken()).isNotBlank()
         );
+    }
+
+    @Test
+    void 사용자_정보를_조회한다() {
+        // given
+        final String signToken = signTokenProvider.createToken(멤버1.getId());
+        final String accessToken = toObject(post(MEMBER_BASE_PATH + "/baby",
+                Map.of("Authorization", "Bearer " + signToken), 멤버_가입_요청), MemberSignUpResponse.class).accessToken();
+
+        // when
+        final ExtractableResponse<Response> response =
+                get(MEMBER_BASE_PATH, Map.of("Authorization", "Bearer " + accessToken));
+
+        // then
+        Assertions.assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(toObject(response, MemberResponse.class)).isEqualTo(
+                        new MemberResponse(멤버_가입_요청.getName(), "", 멤버_가입_요청.getIconName(), IconColor.COLOR_1.name()))
+        );
+    }
+
+    @Test
+    void 존재하지않는_사용자_정보를_조회_시_404를_반환한다() {
+        // given
+        final String invalidAccessToken = accessTokenProvider.createToken("invalidMemberId");
+
+        // when
+        final ExtractableResponse<Response> response =
+                get(MEMBER_BASE_PATH, Map.of("Authorization", "Bearer " + invalidAccessToken));
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+    }
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        public Picker<IconColor> picker() {
+            return colors -> IconColor.COLOR_1;
+        }
     }
 }

--- a/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
@@ -7,6 +7,7 @@ import static com.baba.back.fixture.DomainFixture.아기1;
 import static com.baba.back.fixture.DomainFixture.아기2;
 import static com.baba.back.fixture.RequestFixture.멤버_가입_요청;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -20,12 +21,15 @@ import com.baba.back.baby.repository.BabyRepository;
 import com.baba.back.oauth.domain.Picker;
 import com.baba.back.oauth.domain.member.IconColor;
 import com.baba.back.oauth.domain.member.Member;
+import com.baba.back.oauth.dto.MemberResponse;
 import com.baba.back.oauth.dto.MemberSignUpRequest;
 import com.baba.back.oauth.dto.MemberSignUpResponse;
 import com.baba.back.oauth.exception.MemberBadRequestException;
+import com.baba.back.oauth.exception.MemberNotFoundException;
 import com.baba.back.oauth.repository.MemberRepository;
 import com.baba.back.relation.domain.Relation;
 import com.baba.back.relation.repository.RelationRepository;
+import java.util.Optional;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -102,5 +106,37 @@ class MemberServiceTest {
                 () -> assertThat(response.accessToken()).isEqualTo(accessToken),
                 () -> assertThat(response.refreshToken()).isEqualTo(refreshToken)
         );
+    }
+
+    @Test
+    void 멤버의_정보를_조회한다() {
+        final String memberId = "memberId";
+
+        // given
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(멤버1));
+
+        // when
+        final MemberResponse response = memberService.findMember(memberId);
+
+        // then
+        assertThat(response).isEqualTo(
+                new MemberResponse(
+                        멤버1.getName(),
+                        멤버1.getIntroduction(),
+                        멤버1.getIconName(),
+                        멤버1.getIconColor()
+                )
+        );
+    }
+
+    @Test
+    void 존재하지_않는_멤버의_정보를_조회할_수_없다() {
+        final String invalidMemberId = "invalidMemberId";
+
+        // given
+        given(memberRepository.findById(invalidMemberId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> memberService.findMember(invalidMemberId)).isInstanceOf(MemberNotFoundException.class);
     }
 }


### PR DESCRIPTION
## 상세 내용
사용자 정보 조회 API를 구현하였습니다.
구현 자체는 간단했으나 한가지 변경점이 있습니다.

value object의 필드명을 `value` 로 변경하였습니다.
이전까지는 사실 바꾸기가 귀찮아서.. 얘기도 안꺼냈었습니다.
그런데 이번 API를 만들면서 `value`로 바꿔야할 필요성을 느꼈습니다.
예를 들어 사용자의 이름 (Name) 클래스에서 이름의 값을 꺼내오려면 `name.getName()`을 실행해야했습니다.
이름.이름() .. 뭔가 어색하네요.
이름.값() 으로 변경하고 싶어졌습니다.
이에 대한 의견이 궁금하네요.


Close #61 
