### PR TITLE
AcceptanceTest의 요청을 메소드로 만든다.

### DIFF
--- a/back/src/main/java/com/baba/back/oauth/domain/token/Token.java
+++ b/back/src/main/java/com/baba/back/oauth/domain/token/Token.java
@@ -40,4 +40,8 @@ public class Token {
             throw new TokenBadRequestException("token은 null일 수 없습니다.");
         }
     }
+
+    public void update(String value) {
+        this.value = value;
+    }
 }

--- a/back/src/main/java/com/baba/back/oauth/repository/TokenRepository.java
+++ b/back/src/main/java/com/baba/back/oauth/repository/TokenRepository.java
@@ -2,8 +2,11 @@ package com.baba.back.oauth.repository;
 
 import com.baba.back.oauth.domain.member.Member;
 import com.baba.back.oauth.domain.token.Token;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TokenRepository extends JpaRepository<Token, String> {
     boolean existsByMemberAndValue(Member member, String value);
+
+    Optional<Token> findByMember(Member member);
 }

--- a/back/src/test/java/com/baba/back/AcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/AcceptanceTest.java
@@ -3,8 +3,8 @@ package com.baba.back;
 import static com.baba.back.SimpleRestAssured.get;
 import static com.baba.back.SimpleRestAssured.post;
 import static com.baba.back.fixture.DomainFixture.멤버1;
-import static com.baba.back.fixture.RequestFixture.멤버_가입_요청;
-import static com.baba.back.fixture.RequestFixture.소셜_토큰_요청;
+import static com.baba.back.fixture.RequestFixture.멤버_가입_요청_데이터;
+import static com.baba.back.fixture.RequestFixture.소셜_토큰_요청_데이터;
 
 import com.baba.back.oauth.dto.MemberSignUpRequest;
 import com.baba.back.oauth.dto.TokenRefreshRequest;
@@ -26,6 +26,7 @@ public class AcceptanceTest {
     private static final String BASE_PATH = "/api";
     private static final String MEMBER_BASE_PATH = BASE_PATH + "/members";
     private static final String AUTH_BASE_PATH = BASE_PATH + "/auth";
+
     @Autowired
     protected SignTokenProvider signTokenProvider;
     @LocalServerPort
@@ -33,7 +34,7 @@ public class AcceptanceTest {
 
     protected ExtractableResponse<Response> 아기_등록_회원가입_요청_멤버_1() {
         final String signToken = signTokenProvider.createToken(멤버1.getId());
-        return 아기_등록_회원가입_요청(signToken, 멤버_가입_요청);
+        return 아기_등록_회원가입_요청(signToken, 멤버_가입_요청_데이터);
     }
 
     protected ExtractableResponse<Response> 아기_등록_회원가입_요청(String signToken, MemberSignUpRequest request) {
@@ -45,7 +46,7 @@ public class AcceptanceTest {
     }
 
     protected ExtractableResponse<Response> 소셜_로그인_요청() {
-        return post(AUTH_BASE_PATH + "/login", 소셜_토큰_요청);
+        return post(AUTH_BASE_PATH + "/login", 소셜_토큰_요청_데이터);
     }
 
     protected ExtractableResponse<Response> 토큰_재발급_요청(TokenRefreshRequest request) {

--- a/back/src/test/java/com/baba/back/AcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/AcceptanceTest.java
@@ -4,8 +4,10 @@ import static com.baba.back.SimpleRestAssured.get;
 import static com.baba.back.SimpleRestAssured.post;
 import static com.baba.back.fixture.DomainFixture.멤버1;
 import static com.baba.back.fixture.RequestFixture.멤버_가입_요청;
+import static com.baba.back.fixture.RequestFixture.소셜_토큰_요청;
 
 import com.baba.back.oauth.dto.MemberSignUpRequest;
+import com.baba.back.oauth.dto.TokenRefreshRequest;
 import com.baba.back.oauth.service.SignTokenProvider;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -21,11 +23,11 @@ import org.springframework.test.context.jdbc.Sql;
 @Sql("/truncate.sql")
 public class AcceptanceTest {
 
-    @Autowired
-    protected SignTokenProvider signTokenProvider;
     private static final String BASE_PATH = "/api";
     private static final String MEMBER_BASE_PATH = BASE_PATH + "/members";
-
+    private static final String AUTH_BASE_PATH = BASE_PATH + "/auth";
+    @Autowired
+    protected SignTokenProvider signTokenProvider;
     @LocalServerPort
     int port;
 
@@ -40,6 +42,14 @@ public class AcceptanceTest {
 
     protected ExtractableResponse<Response> 사용자_정보_요청(String accessToken) {
         return get(MEMBER_BASE_PATH, Map.of("Authorization", "Bearer " + accessToken));
+    }
+
+    protected ExtractableResponse<Response> 소셜_로그인_요청() {
+        return post(AUTH_BASE_PATH + "/login", 소셜_토큰_요청);
+    }
+
+    protected ExtractableResponse<Response> 토큰_재발급_요청(TokenRefreshRequest request) {
+        return post(AUTH_BASE_PATH + "/refresh", request);
     }
 
     @BeforeEach

--- a/back/src/test/java/com/baba/back/AcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/AcceptanceTest.java
@@ -1,7 +1,18 @@
 package com.baba.back;
 
+import static com.baba.back.SimpleRestAssured.get;
+import static com.baba.back.SimpleRestAssured.post;
+import static com.baba.back.fixture.DomainFixture.멤버1;
+import static com.baba.back.fixture.RequestFixture.멤버_가입_요청;
+
+import com.baba.back.oauth.dto.MemberSignUpRequest;
+import com.baba.back.oauth.service.SignTokenProvider;
 import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.jdbc.Sql;
@@ -10,11 +21,30 @@ import org.springframework.test.context.jdbc.Sql;
 @Sql("/truncate.sql")
 public class AcceptanceTest {
 
+    @Autowired
+    protected SignTokenProvider signTokenProvider;
+    private static final String BASE_PATH = "/api";
+    private static final String MEMBER_BASE_PATH = BASE_PATH + "/members";
+
     @LocalServerPort
     int port;
+
+    protected ExtractableResponse<Response> 아기_등록_회원가입_요청_멤버_1() {
+        final String signToken = signTokenProvider.createToken(멤버1.getId());
+        return 아기_등록_회원가입_요청(signToken, 멤버_가입_요청);
+    }
+
+    protected ExtractableResponse<Response> 아기_등록_회원가입_요청(String signToken, MemberSignUpRequest request) {
+        return post(MEMBER_BASE_PATH + "/baby", Map.of("Authorization", "Bearer " + signToken), request);
+    }
+
+    protected ExtractableResponse<Response> 사용자_정보_요청(String accessToken) {
+        return get(MEMBER_BASE_PATH, Map.of("Authorization", "Bearer " + accessToken));
+    }
 
     @BeforeEach
     public void setUp() {
         RestAssured.port = port;
     }
+
 }

--- a/back/src/test/java/com/baba/back/content/service/ContentServiceTest.java
+++ b/back/src/test/java/com/baba/back/content/service/ContentServiceTest.java
@@ -6,7 +6,7 @@ import static com.baba.back.fixture.DomainFixture.멤버1;
 import static com.baba.back.fixture.DomainFixture.아기1;
 import static com.baba.back.fixture.DomainFixture.좋아요;
 import static com.baba.back.fixture.DomainFixture.컨텐츠;
-import static com.baba.back.fixture.RequestFixture.컨텐츠_생성_요청;
+import static com.baba.back.fixture.RequestFixture.컨텐츠_생성_요청_데이터;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -75,7 +75,7 @@ class ContentServiceTest {
         given(memberRepository.findById(any())).willReturn(Optional.empty());
 
         // when & then
-        Assertions.assertThatThrownBy(() -> contentService.createContent(컨텐츠_생성_요청, MEMBER_ID, BABY_ID))
+        Assertions.assertThatThrownBy(() -> contentService.createContent(컨텐츠_생성_요청_데이터, MEMBER_ID, BABY_ID))
                 .isInstanceOf(MemberNotFoundException.class);
     }
 
@@ -86,7 +86,7 @@ class ContentServiceTest {
         given(babyRepository.findById(any())).willReturn(Optional.empty());
 
         // when & then
-        Assertions.assertThatThrownBy(() -> contentService.createContent(컨텐츠_생성_요청, MEMBER_ID, BABY_ID))
+        Assertions.assertThatThrownBy(() -> contentService.createContent(컨텐츠_생성_요청_데이터, MEMBER_ID, BABY_ID))
                 .isInstanceOf(BabyNotFoundException.class);
     }
 
@@ -98,7 +98,7 @@ class ContentServiceTest {
         given(relationRepository.findByMemberAndBaby(any(), any())).willReturn(Optional.empty());
 
         // when & then
-        Assertions.assertThatThrownBy(() -> contentService.createContent(컨텐츠_생성_요청, MEMBER_ID, BABY_ID))
+        Assertions.assertThatThrownBy(() -> contentService.createContent(컨텐츠_생성_요청_데이터, MEMBER_ID, BABY_ID))
                 .isInstanceOf(RelationNotFoundException.class);
     }
 
@@ -110,7 +110,7 @@ class ContentServiceTest {
         given(relationRepository.findByMemberAndBaby(any(), any())).willReturn(Optional.of(관계2));
 
         // when & then
-        Assertions.assertThatThrownBy(() -> contentService.createContent(컨텐츠_생성_요청, MEMBER_ID, BABY_ID))
+        Assertions.assertThatThrownBy(() -> contentService.createContent(컨텐츠_생성_요청_데이터, MEMBER_ID, BABY_ID))
                 .isInstanceOf(ContentAuthorizationException.class);
     }
 
@@ -126,7 +126,7 @@ class ContentServiceTest {
         given(contentRepository.existsByContentDateAndBaby(any(), any())).willReturn(true);
 
         // when & then
-        Assertions.assertThatThrownBy(() -> contentService.createContent(컨텐츠_생성_요청, MEMBER_ID, BABY_ID))
+        Assertions.assertThatThrownBy(() -> contentService.createContent(컨텐츠_생성_요청_데이터, MEMBER_ID, BABY_ID))
                 .isInstanceOf(ContentBadRequestException.class);
     }
 
@@ -144,7 +144,7 @@ class ContentServiceTest {
         given(fileHandler.upload(any())).willReturn("VALID_IMAGE_SOURCE");
 
         // when
-        final CreateContentResponse response = contentService.createContent(컨텐츠_생성_요청, MEMBER_ID, BABY_ID);
+        final CreateContentResponse response = contentService.createContent(컨텐츠_생성_요청_데이터, MEMBER_ID, BABY_ID);
 
         // then
         then(contentRepository).should(times(1)).save(any());

--- a/back/src/test/java/com/baba/back/fixture/RequestFixture.java
+++ b/back/src/test/java/com/baba/back/fixture/RequestFixture.java
@@ -5,6 +5,7 @@ import static com.baba.back.content.domain.content.CardStyle.CARD_BASIC_1;
 import com.baba.back.baby.dto.BabyRequest;
 import com.baba.back.content.dto.CreateContentRequest;
 import com.baba.back.oauth.dto.MemberSignUpRequest;
+import com.baba.back.oauth.dto.SocialTokenRequest;
 import java.time.LocalDate;
 import java.util.List;
 import org.springframework.mock.web.MockMultipartFile;
@@ -16,6 +17,9 @@ public class RequestFixture {
     public static final MemberSignUpRequest 멤버_가입_요청 = new MemberSignUpRequest(
             "박재희", "PROFILE_W_1", "엄마", List.of(아기_생성_요청1, 아기_생성_요청2)
     );
+
+    public static final SocialTokenRequest 소셜_토큰_요청 = new SocialTokenRequest("socialToken");
+
     public static final CreateContentRequest 컨텐츠_생성_요청 = new CreateContentRequest(LocalDate.now(), "제목",
             new MockMultipartFile("photo", "file.png", "image/png",
                     "Mock File".getBytes()), CARD_BASIC_1.toString());

--- a/back/src/test/java/com/baba/back/fixture/RequestFixture.java
+++ b/back/src/test/java/com/baba/back/fixture/RequestFixture.java
@@ -12,15 +12,15 @@ import org.springframework.mock.web.MockMultipartFile;
 
 public class RequestFixture {
 
-    public static final BabyRequest 아기_생성_요청1 = new BabyRequest("아기1", LocalDate.now());
-    public static final BabyRequest 아기_생성_요청2 = new BabyRequest("아기2", LocalDate.now());
-    public static final MemberSignUpRequest 멤버_가입_요청 = new MemberSignUpRequest(
-            "박재희", "PROFILE_W_1", "엄마", List.of(아기_생성_요청1, 아기_생성_요청2)
+    public static final BabyRequest 아기_생성_요청_데아터_1 = new BabyRequest("아기1", LocalDate.now());
+    public static final BabyRequest 아기_생성_요청_데이터_2 = new BabyRequest("아기2", LocalDate.now());
+    public static final MemberSignUpRequest 멤버_가입_요청_데이터 = new MemberSignUpRequest(
+            "박재희", "PROFILE_W_1", "엄마", List.of(아기_생성_요청_데아터_1, 아기_생성_요청_데이터_2)
     );
 
-    public static final SocialTokenRequest 소셜_토큰_요청 = new SocialTokenRequest("socialToken");
+    public static final SocialTokenRequest 소셜_토큰_요청_데이터 = new SocialTokenRequest("socialToken");
 
-    public static final CreateContentRequest 컨텐츠_생성_요청 = new CreateContentRequest(LocalDate.now(), "제목",
+    public static final CreateContentRequest 컨텐츠_생성_요청_데이터 = new CreateContentRequest(LocalDate.now(), "제목",
             new MockMultipartFile("photo", "file.png", "image/png",
                     "Mock File".getBytes()), CARD_BASIC_1.toString());
 }

--- a/back/src/test/java/com/baba/back/oauth/acceptance/MemberAcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/acceptance/MemberAcceptanceTest.java
@@ -2,7 +2,7 @@ package com.baba.back.oauth.acceptance;
 
 import static com.baba.back.SimpleRestAssured.toObject;
 import static com.baba.back.fixture.DomainFixture.멤버1;
-import static com.baba.back.fixture.RequestFixture.멤버_가입_요청;
+import static com.baba.back.fixture.RequestFixture.멤버_가입_요청_데이터;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -41,7 +41,7 @@ class MemberAcceptanceTest extends AcceptanceTest {
     @ValueSource(strings = "invalidToken")
     void 아기_등록_회원가입_요청에_유효하지_않은_sign_토큰으로_요청_시_401을_응답한다(String invalidSignToken) {
         // given
-        final ExtractableResponse<Response> response = 아기_등록_회원가입_요청(invalidSignToken, 멤버_가입_요청);
+        final ExtractableResponse<Response> response = 아기_등록_회원가입_요청(invalidSignToken, 멤버_가입_요청_데이터);
 
         // when & then
         assertAll(
@@ -99,7 +99,7 @@ class MemberAcceptanceTest extends AcceptanceTest {
     void 사용자_정보를_조회한다() {
         // given
         final String signToken = signTokenProvider.createToken(멤버1.getId());
-        final ExtractableResponse<Response> 아기_등록_회원가입_응답 = 아기_등록_회원가입_요청(signToken, 멤버_가입_요청);
+        final ExtractableResponse<Response> 아기_등록_회원가입_응답 = 아기_등록_회원가입_요청(signToken, 멤버_가입_요청_데이터);
         final String accessToken = toObject(아기_등록_회원가입_응답, MemberSignUpResponse.class).accessToken();
 
         // when
@@ -109,7 +109,7 @@ class MemberAcceptanceTest extends AcceptanceTest {
         Assertions.assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(toObject(response, MemberResponse.class)).isEqualTo(
-                        new MemberResponse(멤버_가입_요청.getName(), "", 멤버_가입_요청.getIconName(), IconColor.COLOR_1.name())
+                        new MemberResponse(멤버_가입_요청_데이터.getName(), "", 멤버_가입_요청_데이터.getIconName(), IconColor.COLOR_1.name())
                 )
         );
     }

--- a/back/src/test/java/com/baba/back/oauth/acceptance/OAuthAcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/acceptance/OAuthAcceptanceTest.java
@@ -1,9 +1,7 @@
 package com.baba.back.oauth.acceptance;
 
-import static com.baba.back.SimpleRestAssured.post;
 import static com.baba.back.SimpleRestAssured.toObject;
 import static com.baba.back.fixture.DomainFixture.멤버1;
-import static com.baba.back.fixture.RequestFixture.멤버_가입_요청;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
@@ -16,49 +14,32 @@ import com.baba.back.oauth.OAuthClient;
 import com.baba.back.oauth.dto.LoginTokenResponse;
 import com.baba.back.oauth.dto.MemberSignUpResponse;
 import com.baba.back.oauth.dto.SignTokenResponse;
-import com.baba.back.oauth.dto.SocialTokenRequest;
 import com.baba.back.oauth.dto.TokenRefreshRequest;
 import com.baba.back.oauth.dto.TokenRefreshResponse;
-import com.baba.back.oauth.repository.MemberRepository;
 import com.baba.back.oauth.service.RefreshTokenProvider;
-import com.baba.back.oauth.service.SignTokenProvider;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.HttpStatus;
 
-public class OAuthAcceptanceTest extends AcceptanceTest {
-
-    public static final String BASE_URL = "/api/auth";
-    private static final String MEMBER_BASE_PATH = "/api/members/baby";
-    private static final String MEMBER_ID = "memberId";
+class OAuthAcceptanceTest extends AcceptanceTest {
 
     @MockBean
     private OAuthClient oAuthClient;
-
-    @Autowired
-    private SignTokenProvider tokenProvider;
-
-    @Autowired
-    private MemberRepository memberRepository;
 
     @SpyBean
     private RefreshTokenProvider refreshTokenProvider;
 
     @Test
-    void 가입되어_있으면_access_token과_refresh_token_과_200을_응답한다() {
+    void 소셜_로그인_요청_시_이미_가입되어_있으면_access_token과_refresh_token_과_200을_응답한다() {
         // given
-        final SocialTokenRequest request = new SocialTokenRequest("token");
-        memberRepository.save(멤버1);
-
+        아기_등록_회원가입_요청_멤버_1();
         given(oAuthClient.getMemberId(any())).willReturn(멤버1.getId());
 
         // when
-        final ExtractableResponse<Response> response = post(BASE_URL + "/login", request);
+        final ExtractableResponse<Response> response = 소셜_로그인_요청();
 
         // then
         assertAll(
@@ -70,13 +51,12 @@ public class OAuthAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 가입되어_있지_않으면_sign_token_과_404를_응답한다() {
+    void 소셜_로그인_요청_시_가입되어_있지_않으면_sign_token_과_404를_응답한다() {
         // given
-        final SocialTokenRequest request = new SocialTokenRequest("invalidToken");
-        given(oAuthClient.getMemberId(any())).willReturn("invalid member");
+        given(oAuthClient.getMemberId(any())).willReturn("not signed up member");
 
         // when
-        final ExtractableResponse<Response> response = post(BASE_URL + "/login", request);
+        final ExtractableResponse<Response> response = 소셜_로그인_요청();
 
         // then
         assertAll(
@@ -86,19 +66,14 @@ public class OAuthAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 토큰재발급시_refresh토큰의_만료기간이_하루보다_많이_남았으면_access토큰을_재발급하고_201을_응답한다() {
+    void 토큰_재발급_요청_시_refresh토큰의_만료기간이_하루보다_많이_남았으면_access토큰을_재발급하고_201을_응답한다() {
         // given
-        final String token = tokenProvider.createToken(MEMBER_ID);
-        final ExtractableResponse<Response> signUpResponse = post(MEMBER_BASE_PATH,
-                Map.of("Authorization", "Bearer " + token), 멤버_가입_요청);
-
-        final String refreshToken = toObject(signUpResponse, MemberSignUpResponse.class).refreshToken();
+        final ExtractableResponse<Response> 회원가입_응답 = 아기_등록_회원가입_요청_멤버_1();
+        final String refreshToken = toObject(회원가입_응답, MemberSignUpResponse.class).refreshToken();
         given(refreshTokenProvider.isExpiringSoon(refreshToken)).willReturn(false);
 
-        final TokenRefreshRequest request = new TokenRefreshRequest(refreshToken);
-
         // when
-        final ExtractableResponse<Response> response = post(BASE_URL + "/refresh", request);
+        final ExtractableResponse<Response> response = 토큰_재발급_요청(new TokenRefreshRequest(refreshToken));
 
         // then
         assertAll(
@@ -111,19 +86,14 @@ public class OAuthAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 토큰재발급시_refresh토큰의_만료기간이_하루_이하로_남았으면_access토큰과_refresh토큰을_재발급하고_201을_응답한다() {
+    void 토큰_재발급_요청_시_refresh토큰의_만료기간이_하루_이하로_남았으면_access토큰과_refresh토큰을_재발급하고_201을_응답한다() {
         // given
-        final String token = tokenProvider.createToken(MEMBER_ID);
-        final ExtractableResponse<Response> signUpResponse = post(MEMBER_BASE_PATH,
-                Map.of("Authorization", "Bearer " + token), 멤버_가입_요청);
-
-        final String refreshToken = toObject(signUpResponse, MemberSignUpResponse.class).refreshToken();
+        final ExtractableResponse<Response> 회원가입_응답 = 아기_등록_회원가입_요청_멤버_1();
+        final String refreshToken = toObject(회원가입_응답, MemberSignUpResponse.class).refreshToken();
         given(refreshTokenProvider.isExpiringSoon(refreshToken)).willReturn(true);
 
-        final TokenRefreshRequest request = new TokenRefreshRequest(refreshToken);
-
         // when
-        final ExtractableResponse<Response> response = post(BASE_URL + "/refresh", request);
+        final ExtractableResponse<Response> response = 토큰_재발급_요청(new TokenRefreshRequest(refreshToken));
 
         // then
         assertAll(
@@ -133,6 +103,4 @@ public class OAuthAcceptanceTest extends AcceptanceTest {
 
         then(refreshTokenProvider).should(times(2)).createToken(any());
     }
-
-
 }

--- a/back/src/test/java/com/baba/back/oauth/domain/token/TokenTest.java
+++ b/back/src/test/java/com/baba/back/oauth/domain/token/TokenTest.java
@@ -1,22 +1,41 @@
 package com.baba.back.oauth.domain.token;
 
 import static com.baba.back.fixture.DomainFixture.멤버1;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.baba.back.oauth.exception.TokenBadRequestException;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class TokenTest {
     @Test
-    void token은_null일수_없다() {
+    void token값은_null일수_없다() {
         // given
-        String invalidToken = null;
+        final String value = null;
 
         // when & then
-        Assertions.assertThatThrownBy(() -> Token.builder()
+        assertThatThrownBy(() -> Token.builder()
                         .member(멤버1)
-                        .value(invalidToken)
+                        .value(value)
                         .build())
                 .isInstanceOf(TokenBadRequestException.class);
+    }
+
+    @Test
+    void 토큰_값을_변경한다() {
+        // give
+        final String oldValue = "oldValue";
+        final String newValue = "newValue";
+        final Token token = Token.builder()
+                .member(멤버1)
+                .value(oldValue)
+                .build();
+
+        // when
+        token.update(newValue);
+
+        // then
+        assertThat(token.getValue()).isEqualTo(newValue);
+
     }
 }

--- a/back/src/test/java/com/baba/back/oauth/repository/TokenRepositoryTest.java
+++ b/back/src/test/java/com/baba/back/oauth/repository/TokenRepositoryTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.baba.back.oauth.domain.member.Member;
 import com.baba.back.oauth.domain.token.Token;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -23,15 +24,15 @@ class TokenRepositoryTest {
     void 멤버와_토큰값쌍이_DB에_존재하면_true를_반환한다() {
         // given
         final Member member = memberRepository.save(멤버1);
-        final String token = "token";
+        final String value = "token";
 
         tokenRepository.save(Token.builder()
                 .member(member)
-                .value(token)
+                .value(value)
                 .build());
 
         // when
-        final boolean exists = tokenRepository.existsByMemberAndValue(member, token);
+        final boolean exists = tokenRepository.existsByMemberAndValue(member, value);
 
         // then
         assertThat(exists).isTrue();
@@ -50,18 +51,38 @@ class TokenRepositoryTest {
     void 멤버와_토큰값쌍이_DB에_존재하지_않으면_false를_반환한다() {
         // given
         final Member member = memberRepository.save(멤버1);
-        final String validToken = "validToken";
-        final String invalidToken = "invalidToken";
+        final String value = "validToken";
+        final String invalidValue = "invalidToken";
 
         tokenRepository.save(Token.builder()
                 .member(member)
-                .value(validToken)
+                .value(value)
                 .build());
 
         // when
-        final boolean exists = tokenRepository.existsByMemberAndValue(member, invalidToken);
+        final boolean exists = tokenRepository.existsByMemberAndValue(member, invalidValue);
 
         // then
         assertThat(exists).isFalse();
+    }
+
+    @Test
+    void 멤버에_대한_refreshToken이_저장되어있는지_확인한다() {
+        // given
+        final String value = "validToken";
+
+        final Member member = memberRepository.save(멤버1);
+        final Token token = tokenRepository.save(
+                Token.builder()
+                        .member(member)
+                        .value(value)
+                        .build()
+        );
+
+        // when
+        final Token savedToken = tokenRepository.findByMember(member).orElseThrow();
+
+        // then
+        Assertions.assertThat(token).isEqualTo(savedToken);
     }
 }

--- a/back/src/test/java/com/baba/back/oauth/repository/TokenRepositoryTest.java
+++ b/back/src/test/java/com/baba/back/oauth/repository/TokenRepositoryTest.java
@@ -1,7 +1,6 @@
 package com.baba.back.oauth.repository;
 
 import static com.baba.back.fixture.DomainFixture.멤버1;
-import static com.baba.back.fixture.DomainFixture.토큰;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.baba.back.oauth.domain.member.Member;
@@ -39,15 +38,6 @@ class TokenRepositoryTest {
     }
 
     @Test
-    void 인자로_받은_멤버가_없으면_false를_반환한다() {
-        // when
-        final boolean exists = tokenRepository.existsByMemberAndValue(토큰.getMember(), 토큰.getValue());
-
-        // then
-        assertThat(exists).isFalse();
-    }
-
-    @Test
     void 멤버와_토큰값쌍이_DB에_존재하지_않으면_false를_반환한다() {
         // given
         final Member member = memberRepository.save(멤버1);
@@ -67,7 +57,7 @@ class TokenRepositoryTest {
     }
 
     @Test
-    void 멤버에_대한_refreshToken이_저장되어있는지_확인한다() {
+    void 멤버에_대한_refreshToken을_DB에서_조회한다() {
         // given
         final String value = "validToken";
 

--- a/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
@@ -82,7 +82,7 @@ class MemberServiceTest {
         given(memberRepository.existsById(memberId)).willReturn(true);
 
         // when & then
-        Assertions.assertThatThrownBy(() -> memberService.signUp(new MemberSignUpRequest(), memberId))
+        assertThatThrownBy(() -> memberService.signUp(new MemberSignUpRequest(), memberId))
                 .isInstanceOf(MemberBadRequestException.class);
     }
 

--- a/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
@@ -5,7 +5,7 @@ import static com.baba.back.fixture.DomainFixture.관계2;
 import static com.baba.back.fixture.DomainFixture.멤버1;
 import static com.baba.back.fixture.DomainFixture.아기1;
 import static com.baba.back.fixture.DomainFixture.아기2;
-import static com.baba.back.fixture.RequestFixture.멤버_가입_요청;
+import static com.baba.back.fixture.RequestFixture.멤버_가입_요청_데이터;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -33,7 +33,6 @@ import com.baba.back.relation.domain.Relation;
 import com.baba.back.relation.repository.RelationRepository;
 import java.time.Clock;
 import java.util.Optional;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -107,7 +106,7 @@ class MemberServiceTest {
         given(tokenRepository.save(any(Token.class))).willReturn(any());
 
         // when
-        final MemberSignUpResponse response = memberService.signUp(멤버_가입_요청, memberId);
+        final MemberSignUpResponse response = memberService.signUp(멤버_가입_요청_데이터, memberId);
 
         //then
         then(memberRepository).should(times(1)).save(any());

--- a/back/src/test/java/com/baba/back/oauth/service/OAuthServiceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/service/OAuthServiceTest.java
@@ -105,7 +105,7 @@ class OAuthServiceTest {
         final String accessToken = "accessToken";
         final String refreshToken = "refreshToken";
 
-        given(oAuthClient.getMemberId(any())).willReturn(멤버1.getId());
+        given(oAuthClient.getMemberId(validToken)).willReturn(멤버1.getId());
         given(memberRepository.findById(멤버1.getId())).willReturn(Optional.of(멤버1));
         given(accessTokenProvider.createToken(멤버1.getId())).willReturn(accessToken);
         given(refreshTokenProvider.createToken(멤버1.getId())).willReturn(refreshToken);

--- a/back/src/test/java/com/baba/back/oauth/service/RefreshTokenProviderTest.java
+++ b/back/src/test/java/com/baba/back/oauth/service/RefreshTokenProviderTest.java
@@ -16,7 +16,7 @@ class RefreshTokenProviderTest {
     void 만료기간이_하루_이하로_남으면_true를_반환한다() {
         // given
         final String memberId = "memberId";
-        final LocalDateTime now = LocalDateTime.of(2023, 3, 1, 20, 20, 0);
+        final LocalDateTime now = LocalDateTime.now();
         final Clock clock = Clock.fixed(now.atZone(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault());
         refreshTokenProvider = new RefreshTokenProvider(SECRET_KEY, VALIDITY_MILLISECONDS, clock);
         final String refreshToken = refreshTokenProvider.createToken(memberId);
@@ -33,7 +33,7 @@ class RefreshTokenProviderTest {
     void 만료기간이_하루보다_많이_남으면_false를_반환한다() {
         // given
         final String memberId = "memberId";
-        final LocalDateTime now = LocalDateTime.of(2023, 3, 1, 20, 20, 0);
+        final LocalDateTime now = LocalDateTime.now();
         final Clock clock = Clock.fixed(now.atZone(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault());
         refreshTokenProvider = new RefreshTokenProvider(SECRET_KEY, VALIDITY_MILLISECONDS, clock);
         final String refreshToken = refreshTokenProvider.createToken(memberId);


### PR DESCRIPTION
## 상세 내용

요청을 메소드로 만들어서 여러 클래스에서 재사용하고 싶었습니다.
그래서 상위 클래스인 acceptanceTest에 메소드를 정의하도록 변경하였습니다.
알아보기 쉽도록 한국어로 정의하였습니다.

테스트 수정 중 refreshToken 저장에 관련된 오류를 발견하여, refreshToken 저장 부분 수정하였습니다.

테스트 메소드 이름에 대해서는 
`무슨_무슨_요청_시_무슨_응답을_한다`
느낌으로 가면 좋을 것 같아요. 각자 맡은 도메인에 대한 개발을 진행하면서 테스트 명을 조금 더 알아보기 쉽게 변경해봅시다.

ContentAcceptanceTest는 변경하지 않았습니다. API를 추가적으로 생성하면서 수정하겠습니다.
수정 사항이 깔끔하지않을 수 있습니다.. 

Close #65
