### PR TITLE
그룹 추가 시, 그룹 색상을 추가할 수 있도록 변경한다.

### DIFF
--- a/back/src/main/java/com/baba/back/oauth/domain/member/Color.java
+++ b/back/src/main/java/com/baba/back/oauth/domain/member/Color.java
@@ -7,20 +7,20 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-public enum IconColor {
+public enum Color {
     COLOR_1("FFAEBA"), COLOR_2("FF8698"), COLOR_3("FFE3C8"), COLOR_4("FFD2A7"), COLOR_5("FFD400"), COLOR_6("9ED883"),
     COLOR_7("30BE9B"), COLOR_8("81E0D5"), COLOR_9("5BD2FF"), COLOR_10("97BEFF"), COLOR_11("98A2FF"), COLOR_12("BFA1FF");
 
     private final String value;
 
-    public static IconColor from(String color) {
-        return Arrays.stream(IconColor.values())
+    public static Color from(String color) {
+        return Arrays.stream(Color.values())
                 .filter(iconColor -> iconColor.value.equals(color))
                 .findAny()
                 .orElseThrow(() -> new IconColorBadRequestException(color + " 는 잘못된 IconColor 입니다."));
     }
 
-    public static IconColor from(Picker<IconColor> picker) {
-        return picker.pick(List.of(IconColor.values()));
+    public static Color from(Picker<Color> picker) {
+        return picker.pick(List.of(Color.values()));
     }
 }

--- a/back/src/main/java/com/baba/back/oauth/domain/member/Icon.java
+++ b/back/src/main/java/com/baba/back/oauth/domain/member/Icon.java
@@ -16,13 +16,13 @@ import lombok.NoArgsConstructor;
 public class Icon {
 
     @Enumerated(EnumType.STRING)
-    private IconColor iconColor;
+    private Color iconColor;
 
     @Enumerated(EnumType.STRING)
     private IconName iconName;
 
-    public static Icon of(Picker<IconColor> picker, String iconName) {
-        return new Icon(IconColor.from(picker), IconName.from(iconName));
+    public static Icon of(Picker<Color> picker, String iconName) {
+        return new Icon(Color.from(picker), IconName.from(iconName));
     }
 
     public String getIconColor() {

--- a/back/src/main/java/com/baba/back/oauth/domain/member/Icon.java
+++ b/back/src/main/java/com/baba/back/oauth/domain/member/Icon.java
@@ -1,6 +1,5 @@
 package com.baba.back.oauth.domain.member;
 
-import com.baba.back.oauth.domain.Picker;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -21,8 +20,8 @@ public class Icon {
     @Enumerated(EnumType.STRING)
     private IconName iconName;
 
-    public static Icon of(Picker<Color> picker, String iconName) {
-        return new Icon(Color.from(picker), IconName.from(iconName));
+    public static Icon of(Color color, String iconName) {
+        return new Icon(color, IconName.from(iconName));
     }
 
     public String getIconColor() {

--- a/back/src/main/java/com/baba/back/oauth/domain/member/Member.java
+++ b/back/src/main/java/com/baba/back/oauth/domain/member/Member.java
@@ -1,6 +1,5 @@
 package com.baba.back.oauth.domain.member;
 
-import com.baba.back.oauth.domain.Picker;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -26,11 +25,11 @@ public class Member {
     private Icon icon;
 
     @Builder
-    public Member(String id, String name, String introduction, Picker<Color> colorPicker, String iconName) {
+    public Member(String id, String name, String introduction, Color iconColor, String iconName) {
         this.id = id;
         this.name = new Name(name);
         this.introduction = new Introduction(introduction);
-        this.icon = Icon.of(colorPicker, iconName);
+        this.icon = Icon.of(iconColor, iconName);
     }
 
     public String getName() {

--- a/back/src/main/java/com/baba/back/oauth/domain/member/Member.java
+++ b/back/src/main/java/com/baba/back/oauth/domain/member/Member.java
@@ -26,7 +26,7 @@ public class Member {
     private Icon icon;
 
     @Builder
-    public Member(String id, String name, String introduction, Picker<IconColor> colorPicker, String iconName) {
+    public Member(String id, String name, String introduction, Picker<Color> colorPicker, String iconName) {
         this.id = id;
         this.name = new Name(name);
         this.introduction = new Introduction(introduction);

--- a/back/src/main/java/com/baba/back/oauth/service/MemberService.java
+++ b/back/src/main/java/com/baba/back/oauth/service/MemberService.java
@@ -67,7 +67,7 @@ public class MemberService {
                 .name(request.getName())
                 .introduction("")
                 .iconName(request.getIconName())
-                .colorPicker(picker)
+                .iconColor(Color.from(picker))
                 .build());
     }
 

--- a/back/src/main/java/com/baba/back/oauth/service/MemberService.java
+++ b/back/src/main/java/com/baba/back/oauth/service/MemberService.java
@@ -79,7 +79,7 @@ public class MemberService {
     }
 
     private void saveRelations(Babies babies, Member member, String relationName) {
-        Color groupColor = Color.from(picker);
+        final Color groupColor = Color.from(picker);
 
         babies.getBabies()
                 .stream()

--- a/back/src/main/java/com/baba/back/oauth/service/MemberService.java
+++ b/back/src/main/java/com/baba/back/oauth/service/MemberService.java
@@ -79,10 +79,12 @@ public class MemberService {
     }
 
     private void saveRelations(Babies babies, Member member, String relationName) {
+        Color groupColor = Color.from(picker);
+
         babies.getBabies()
                 .stream()
                 .map(baby -> {
-                    final RelationGroup relationGroup = saveRelationGroup(baby);
+                    final RelationGroup relationGroup = saveRelationGroup(baby, groupColor);
                     return Relation.builder()
                             .member(member)
                             .relationName(relationName)
@@ -92,12 +94,15 @@ public class MemberService {
                 .forEach(relationRepository::save);
     }
 
-    private RelationGroup saveRelationGroup(Baby baby) {
-        return relationGroupRepository.save(RelationGroup.builder()
-                .baby(baby)
-                .relationGroupName("가족")
-                .family(true)
-                .build());
+    private RelationGroup saveRelationGroup(Baby baby, Color groupColor) {
+        return relationGroupRepository.save(
+                RelationGroup.builder()
+                        .baby(baby)
+                        .relationGroupName("가족")
+                        .groupColor(groupColor)
+                        .family(true)
+                        .build()
+        );
     }
 
     private void saveRefreshToken(Member member, String refreshToken) {

--- a/back/src/main/java/com/baba/back/oauth/service/MemberService.java
+++ b/back/src/main/java/com/baba/back/oauth/service/MemberService.java
@@ -5,7 +5,7 @@ import com.baba.back.baby.domain.Baby;
 import com.baba.back.baby.domain.IdConstructor;
 import com.baba.back.baby.repository.BabyRepository;
 import com.baba.back.oauth.domain.Picker;
-import com.baba.back.oauth.domain.member.IconColor;
+import com.baba.back.oauth.domain.member.Color;
 import com.baba.back.oauth.domain.member.Member;
 import com.baba.back.oauth.domain.token.Token;
 import com.baba.back.oauth.dto.MemberResponse;
@@ -34,7 +34,7 @@ public class MemberService {
     private final BabyRepository babyRepository;
     private final RelationGroupRepository relationGroupRepository;
     private final RelationRepository relationRepository;
-    private final Picker<IconColor> picker;
+    private final Picker<Color> picker;
     private final IdConstructor idConstructor;
     private final AccessTokenProvider accessTokenProvider;
     private final RefreshTokenProvider refreshTokenProvider;

--- a/back/src/main/java/com/baba/back/relation/domain/RelationGroup.java
+++ b/back/src/main/java/com/baba/back/relation/domain/RelationGroup.java
@@ -1,11 +1,14 @@
 package com.baba.back.relation.domain;
 
 import com.baba.back.baby.domain.Baby;
+import com.baba.back.oauth.domain.member.Color;
 import com.baba.back.oauth.domain.member.Name;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -30,12 +33,16 @@ public class RelationGroup {
     @AttributeOverride(name = "value", column = @Column(name = "relation_group_name"))
     private Name relationGroupName;
 
+    @Enumerated(EnumType.STRING)
+    private Color groupColor;
+
     private boolean family;
 
     @Builder
-    public RelationGroup(Baby baby, String relationGroupName, boolean family) {
+    public RelationGroup(Baby baby, String relationGroupName, Color groupColor, boolean family) {
         this.baby = baby;
         this.relationGroupName = new Name(relationGroupName);
+        this.groupColor = groupColor;
         this.family = family;
     }
 }

--- a/back/src/test/java/com/baba/back/fixture/DomainFixture.java
+++ b/back/src/test/java/com/baba/back/fixture/DomainFixture.java
@@ -19,7 +19,7 @@ public class DomainFixture {
             .name("멤버1")
             .introduction("안녕하세요")
             .iconName(IconName.PROFILE_G_1.toString())
-            .colorPicker(colors -> Color.COLOR_1)
+            .iconColor(Color.COLOR_1)
             .build();
 
     public static final Baby 아기1 = Baby.builder()

--- a/back/src/test/java/com/baba/back/fixture/DomainFixture.java
+++ b/back/src/test/java/com/baba/back/fixture/DomainFixture.java
@@ -4,7 +4,7 @@ import com.baba.back.baby.domain.Baby;
 import com.baba.back.content.domain.Like;
 import com.baba.back.content.domain.content.CardStyle;
 import com.baba.back.content.domain.content.Content;
-import com.baba.back.oauth.domain.member.IconColor;
+import com.baba.back.oauth.domain.member.Color;
 import com.baba.back.oauth.domain.member.IconName;
 import com.baba.back.oauth.domain.member.Member;
 import com.baba.back.oauth.domain.token.Token;
@@ -19,7 +19,7 @@ public class DomainFixture {
             .name("멤버1")
             .introduction("안녕하세요")
             .iconName(IconName.PROFILE_G_1.toString())
-            .colorPicker(colors -> IconColor.COLOR_1)
+            .colorPicker(colors -> Color.COLOR_1)
             .build();
 
     public static final Baby 아기1 = Baby.builder()

--- a/back/src/test/java/com/baba/back/oauth/acceptance/MemberAcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/acceptance/MemberAcceptanceTest.java
@@ -10,7 +10,7 @@ import com.baba.back.AcceptanceTest;
 import com.baba.back.baby.dto.BabyRequest;
 import com.baba.back.common.dto.ExceptionResponse;
 import com.baba.back.oauth.domain.Picker;
-import com.baba.back.oauth.domain.member.IconColor;
+import com.baba.back.oauth.domain.member.Color;
 import com.baba.back.oauth.dto.MemberResponse;
 import com.baba.back.oauth.dto.MemberSignUpRequest;
 import com.baba.back.oauth.dto.MemberSignUpResponse;
@@ -109,7 +109,7 @@ class MemberAcceptanceTest extends AcceptanceTest {
         Assertions.assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(toObject(response, MemberResponse.class)).isEqualTo(
-                        new MemberResponse(멤버_가입_요청_데이터.getName(), "", 멤버_가입_요청_데이터.getIconName(), IconColor.COLOR_1.name())
+                        new MemberResponse(멤버_가입_요청_데이터.getName(), "", 멤버_가입_요청_데이터.getIconName(), Color.COLOR_1.name())
                 )
         );
     }
@@ -129,8 +129,8 @@ class MemberAcceptanceTest extends AcceptanceTest {
     @TestConfiguration
     static class TestConfig {
         @Bean
-        public Picker<IconColor> picker() {
-            return colors -> IconColor.COLOR_1;
+        public Picker<Color> picker() {
+            return colors -> Color.COLOR_1;
         }
     }
 }

--- a/back/src/test/java/com/baba/back/oauth/domain/member/ColorTest.java
+++ b/back/src/test/java/com/baba/back/oauth/domain/member/ColorTest.java
@@ -11,32 +11,32 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-class IconColorTest {
+class ColorTest {
 
     @Test
     void 아이콘_색을_선택한다() {
         // given
-        Picker<IconColor> picker = colors -> IconColor.COLOR_1;
+        Picker<Color> picker = colors -> Color.COLOR_1;
 
         // when
-        final IconColor iconColor = IconColor.from(picker);
+        final Color color = Color.from(picker);
 
         // then
-        Assertions.assertThat(iconColor).isEqualTo(IconColor.COLOR_1);
+        Assertions.assertThat(color).isEqualTo(Color.COLOR_1);
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"123", "aaaaaa"})
     @NullAndEmptySource
     void 유효하지_않은_아이콘_색을_선택하면_예외를_던진다(String color) {
-        assertThatThrownBy(() -> IconColor.from(color))
+        assertThatThrownBy(() -> Color.from(color))
                 .isInstanceOf(IconColorBadRequestException.class);
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"FFAEBA", "FF8698", "FFE3C8"})
     void 유효한_아이콘_색을_선택한다(String color) {
-        assertThatCode(() -> IconColor.from(color))
+        assertThatCode(() -> Color.from(color))
                 .doesNotThrowAnyException();
     }
 }

--- a/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
@@ -21,7 +21,7 @@ import com.baba.back.baby.domain.Baby;
 import com.baba.back.baby.domain.IdConstructor;
 import com.baba.back.baby.repository.BabyRepository;
 import com.baba.back.oauth.domain.Picker;
-import com.baba.back.oauth.domain.member.IconColor;
+import com.baba.back.oauth.domain.member.Color;
 import com.baba.back.oauth.domain.member.Member;
 import com.baba.back.oauth.domain.token.Token;
 import com.baba.back.oauth.dto.MemberResponse;
@@ -63,7 +63,7 @@ class MemberServiceTest {
     private RelationRepository relationRepository;
 
     @Spy
-    private Picker<IconColor> picker;
+    private Picker<Color> picker;
 
     @Mock
     private Clock clock;
@@ -101,7 +101,7 @@ class MemberServiceTest {
         final Clock now = Clock.systemDefaultZone();
 
         given(memberRepository.existsById(memberId)).willReturn(false);
-        given(picker.pick(anyList())).willReturn(IconColor.COLOR_1);
+        given(picker.pick(anyList())).willReturn(Color.COLOR_1);
         given(memberRepository.save(any(Member.class))).willReturn(멤버1);
         given(idConstructor.createId()).willReturn(아기1.getId(), 아기2.getId());
         given(clock.instant()).willReturn(now.instant());


### PR DESCRIPTION
## 상세 내용
그룹 추가 시, 그룹 색상을 추가할 수 있도록 relationGroup에 groupColor 필드를 추가했습니다.

색상이라는 것이 icon의 색깔을 의미하는 것일 수도 있고, 그룹의 색깔을 의미하는 것일 수도 있어서 Color 라는 이름으로 변경하였습니다.
물론 둘다 icon의 색깔을 나타내는 것이지만, 둘다 iconColor로 나타내면 그룹 컬러라는 것이 애매해지는 것 같아서 Color로 변경했습니다.

도메인에서 picker에 대한 의존성을 줄이고자하였습니다.
원래 picker를 의존하는 클래스가 service, member, icon 3개가 존재했습니다.
따라서 service에서 color를 생성하도록 하여, service에서만 picker를 의존하도록 변경하였습니다.

Close #73 
