### PR TITLE
등록된 아기 리스트를 조회한다.

### DIFF
--- a/back/src/main/java/com/baba/back/baby/controller/BabyController.java
+++ b/back/src/main/java/com/baba/back/baby/controller/BabyController.java
@@ -1,8 +1,16 @@
 package com.baba.back.baby.controller;
 
+import com.baba.back.baby.dto.BabiesResponse;
 import com.baba.back.baby.service.BabyService;
+import com.baba.back.oauth.support.Login;
+import com.baba.back.swagger.IntervalServerErrorResponse;
+import com.baba.back.swagger.NotFoundResponse;
+import com.baba.back.swagger.OkResponse;
+import com.baba.back.swagger.UnAuthorizedResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "아기 관련 API")
@@ -11,4 +19,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class BabyController {
 
     private final BabyService babyService;
+
+    @Operation(summary = "추가된 전체 아기 조회 요청")
+    @OkResponse
+    @UnAuthorizedResponse
+    @NotFoundResponse
+    @IntervalServerErrorResponse
+    @GetMapping("/baby")
+    public BabiesResponse findBabies(@Login String memberId) {
+        return babyService.findBabies(memberId);
+    }
 }

--- a/back/src/main/java/com/baba/back/baby/domain/Baby.java
+++ b/back/src/main/java/com/baba/back/baby/domain/Baby.java
@@ -33,4 +33,8 @@ public class Baby {
     public LocalDate getBirthday() {
         return birthday.getBirthday();
     }
+
+    public String getName() {
+        return this.name.getValue();
+    }
 }

--- a/back/src/main/java/com/baba/back/baby/domain/Relations.java
+++ b/back/src/main/java/com/baba/back/baby/domain/Relations.java
@@ -1,0 +1,30 @@
+package com.baba.back.baby.domain;
+
+import com.baba.back.relation.domain.Relation;
+import com.baba.back.relation.domain.RelationGroup;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Relations {
+
+    private final List<Relation> values;
+
+    public Relations(List<Relation> values) {
+        this.values = new ArrayList<>(values);
+    }
+
+    public List<RelationGroup> getMyFamilyGroup() {
+        return getRelationGroupBy(true);
+    }
+
+    public List<RelationGroup> getOthersFamilyGroup() {
+        return getRelationGroupBy(false);
+    }
+
+    private List<RelationGroup> getRelationGroupBy(boolean isFamily) {
+        return values.stream()
+                .map(Relation::getRelationGroup)
+                .filter(relation -> relation.isFamily() == isFamily)
+                .toList();
+    }
+}

--- a/back/src/main/java/com/baba/back/baby/dto/BabiesResponse.java
+++ b/back/src/main/java/com/baba/back/baby/dto/BabiesResponse.java
@@ -1,0 +1,6 @@
+package com.baba.back.baby.dto;
+
+import java.util.List;
+
+public record BabiesResponse(List<BabyResponse> myBaby, List<BabyResponse> others) {
+}

--- a/back/src/main/java/com/baba/back/baby/dto/BabyResponse.java
+++ b/back/src/main/java/com/baba/back/baby/dto/BabyResponse.java
@@ -1,0 +1,9 @@
+package com.baba.back.baby.dto;
+
+public record BabyResponse(String babyId, String groupColor, String name) implements Comparable<BabyResponse> {
+
+    @Override
+    public int compareTo(BabyResponse o) {
+        return this.name.compareTo(o.name);
+    }
+}

--- a/back/src/main/java/com/baba/back/baby/service/BabyService.java
+++ b/back/src/main/java/com/baba/back/baby/service/BabyService.java
@@ -1,6 +1,6 @@
 package com.baba.back.baby.service;
 
-import com.baba.back.baby.domain.Relations;
+import com.baba.back.relation.domain.Relations;
 import com.baba.back.baby.dto.BabiesResponse;
 import com.baba.back.baby.dto.BabyResponse;
 import com.baba.back.oauth.domain.member.Member;

--- a/back/src/main/java/com/baba/back/baby/service/BabyService.java
+++ b/back/src/main/java/com/baba/back/baby/service/BabyService.java
@@ -23,7 +23,7 @@ public class BabyService {
 
     public BabiesResponse findBabies(String memberId) {
         final Member member = findMember(memberId);
-        final Relations relations = new Relations(relationRepository.findByMember(member));
+        final Relations relations = new Relations(relationRepository.findAllByMember(member));
         final List<RelationGroup> myFamilyGroups = relations.getMyFamilyGroup();
         final List<RelationGroup> othersFamilyGroups = relations.getOthersFamilyGroup();
 

--- a/back/src/main/java/com/baba/back/baby/service/BabyService.java
+++ b/back/src/main/java/com/baba/back/baby/service/BabyService.java
@@ -1,8 +1,15 @@
 package com.baba.back.baby.service;
 
+import com.baba.back.baby.domain.Relations;
+import com.baba.back.baby.dto.BabiesResponse;
+import com.baba.back.baby.dto.BabyResponse;
+import com.baba.back.oauth.domain.member.Member;
+import com.baba.back.oauth.exception.MemberNotFoundException;
 import com.baba.back.oauth.repository.MemberRepository;
+import com.baba.back.relation.domain.RelationGroup;
 import com.baba.back.relation.repository.RelationRepository;
 import jakarta.transaction.Transactional;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,4 +21,29 @@ public class BabyService {
     private final RelationRepository relationRepository;
     private final MemberRepository memberRepository;
 
+    public BabiesResponse findBabies(String memberId) {
+        final Member member = findMember(memberId);
+        final Relations relations = new Relations(relationRepository.findByMember(member));
+        final List<RelationGroup> myFamilyGroups = relations.getMyFamilyGroup();
+        final List<RelationGroup> othersFamilyGroups = relations.getOthersFamilyGroup();
+
+        return getBabiesResponse(myFamilyGroups, othersFamilyGroups);
+    }
+
+    private Member findMember(String memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(memberId + "에 해당하는 멤버가 존재하지 않습니다."));
+    }
+
+    private BabiesResponse getBabiesResponse(List<RelationGroup> myFamilyGroups,
+                                             List<RelationGroup> othersFamilyGroups) {
+        return new BabiesResponse(getBabyResponse(myFamilyGroups), getBabyResponse(othersFamilyGroups));
+    }
+
+    private List<BabyResponse> getBabyResponse(List<RelationGroup> groups) {
+        return groups.stream()
+                .map(group -> new BabyResponse(group.getBabyId(), group.getGroupColor(), group.getBabyName()))
+                .sorted()
+                .toList();
+    }
 }

--- a/back/src/main/java/com/baba/back/oauth/domain/member/Color.java
+++ b/back/src/main/java/com/baba/back/oauth/domain/member/Color.java
@@ -4,8 +4,10 @@ import com.baba.back.oauth.domain.Picker;
 import com.baba.back.oauth.exception.IconColorBadRequestException;
 import java.util.Arrays;
 import java.util.List;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Getter
 @RequiredArgsConstructor
 public enum Color {
     COLOR_1("FFAEBA"), COLOR_2("FF8698"), COLOR_3("FFE3C8"), COLOR_4("FFD2A7"), COLOR_5("FFD400"), COLOR_6("9ED883"),

--- a/back/src/main/java/com/baba/back/relation/domain/RelationGroup.java
+++ b/back/src/main/java/com/baba/back/relation/domain/RelationGroup.java
@@ -45,4 +45,16 @@ public class RelationGroup {
         this.groupColor = groupColor;
         this.family = family;
     }
+
+    public String getBabyId() {
+        return this.baby.getId();
+    }
+
+    public String getBabyName() {
+        return this.baby.getName();
+    }
+
+    public String getGroupColor() {
+        return this.groupColor.name();
+    }
 }

--- a/back/src/main/java/com/baba/back/relation/domain/RelationGroup.java
+++ b/back/src/main/java/com/baba/back/relation/domain/RelationGroup.java
@@ -55,6 +55,6 @@ public class RelationGroup {
     }
 
     public String getGroupColor() {
-        return this.groupColor.name();
+        return this.groupColor.getValue();
     }
 }

--- a/back/src/main/java/com/baba/back/relation/domain/Relations.java
+++ b/back/src/main/java/com/baba/back/relation/domain/Relations.java
@@ -1,7 +1,5 @@
-package com.baba.back.baby.domain;
+package com.baba.back.relation.domain;
 
-import com.baba.back.relation.domain.Relation;
-import com.baba.back.relation.domain.RelationGroup;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/back/src/main/java/com/baba/back/relation/repository/RelationRepository.java
+++ b/back/src/main/java/com/baba/back/relation/repository/RelationRepository.java
@@ -14,5 +14,5 @@ public interface RelationRepository extends JpaRepository<Relation, Long> {
     Optional<Relation> findByMemberAndBaby(@Param("member") Member member,
                                            @Param("baby") Baby baby);
 
-    List<Relation> findByMember(Member member);
+    List<Relation> findAllByMember(Member member);
 }

--- a/back/src/main/java/com/baba/back/relation/repository/RelationRepository.java
+++ b/back/src/main/java/com/baba/back/relation/repository/RelationRepository.java
@@ -3,6 +3,7 @@ package com.baba.back.relation.repository;
 import com.baba.back.baby.domain.Baby;
 import com.baba.back.oauth.domain.member.Member;
 import com.baba.back.relation.domain.Relation;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -12,4 +13,6 @@ public interface RelationRepository extends JpaRepository<Relation, Long> {
     @Query("select r from Relation r where r.member = :member and r.relationGroup.baby = :baby")
     Optional<Relation> findByMemberAndBaby(@Param("member") Member member,
                                            @Param("baby") Baby baby);
+
+    List<Relation> findByMember(Member member);
 }

--- a/back/src/test/java/com/baba/back/AcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/AcceptanceTest.java
@@ -26,6 +26,7 @@ public class AcceptanceTest {
     private static final String BASE_PATH = "/api";
     private static final String MEMBER_BASE_PATH = BASE_PATH + "/members";
     private static final String AUTH_BASE_PATH = BASE_PATH + "/auth";
+    private static final String BABY_BASE_PATH = BASE_PATH + "/baby";
 
     @Autowired
     protected SignTokenProvider signTokenProvider;
@@ -51,6 +52,10 @@ public class AcceptanceTest {
 
     protected ExtractableResponse<Response> 토큰_재발급_요청(TokenRefreshRequest request) {
         return post(AUTH_BASE_PATH + "/refresh", request);
+    }
+
+    protected ExtractableResponse<Response> 아기_리스트_조회_요청(String accessToken) {
+        return get(BABY_BASE_PATH, Map.of("Authorization", "Bearer " + accessToken));
     }
 
     @BeforeEach

--- a/back/src/test/java/com/baba/back/baby/acceptance/BabyAcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/baby/acceptance/BabyAcceptanceTest.java
@@ -21,9 +21,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpStatus;
 
 class BabyAcceptanceTest extends AcceptanceTest {
-    /**
-     * 아기 초대 API 생성 후 다른 아기 추가하여 테스트 진행
-     */
+
+    // TODO: 2023/03/09 아기 초대 API 생성 후 다른 아기 추가하여 테스트 진행한다.
     @Test
     void 아기_리스트_요청_시_등록된_아기가_조회된다() {
         // given

--- a/back/src/test/java/com/baba/back/baby/acceptance/BabyAcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/baby/acceptance/BabyAcceptanceTest.java
@@ -1,26 +1,60 @@
 package com.baba.back.baby.acceptance;
 
+import static com.baba.back.SimpleRestAssured.toObject;
+import static com.baba.back.fixture.DomainFixture.아기1;
+import static com.baba.back.fixture.DomainFixture.아기2;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import com.baba.back.AcceptanceTest;
-import com.baba.back.baby.repository.BabyRepository;
-import com.baba.back.oauth.repository.MemberRepository;
-import com.baba.back.oauth.service.AccessTokenProvider;
-import com.baba.back.relation.repository.RelationRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import com.baba.back.baby.dto.BabiesResponse;
+import com.baba.back.baby.dto.BabyResponse;
+import com.baba.back.oauth.domain.Picker;
+import com.baba.back.oauth.domain.member.Color;
+import com.baba.back.oauth.dto.MemberSignUpResponse;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpStatus;
 
-public class BabyAcceptanceTest extends AcceptanceTest {
+class BabyAcceptanceTest extends AcceptanceTest {
+    /**
+     * 아기 초대 API 생성 후 다른 아기 추가하여 테스트 진행
+     */
+    @Test
+    void 아기_리스트_요청_시_등록된_아기가_조회된다() {
+        // given
+        final String accessToken = toObject(아기_등록_회원가입_요청_멤버_1(), MemberSignUpResponse.class).accessToken();
 
-    public static final String BABY_BASE_PATH = "/api/baby";
+        // when
+        final ExtractableResponse<Response> response = 아기_리스트_조회_요청(accessToken);
 
-    @Autowired
-    private AccessTokenProvider tokenProvider;
+        // then
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(toObject(response, BabiesResponse.class))
+                        .usingRecursiveComparison()
+                        .ignoringFields("myBaby.babyId", "others.babyId")
+                        .isEqualTo(
+                                new BabiesResponse(
+                                        List.of(
+                                                new BabyResponse(아기1.getId(), Color.COLOR_1.getValue(), 아기1.getName()),
+                                                new BabyResponse(아기2.getId(), Color.COLOR_1.getValue(), 아기2.getName())
+                                        ),
+                                        List.of()
+                                )
+                        )
+        );
+    }
 
-    @Autowired
-    private MemberRepository memberRepository;
-
-    @Autowired
-    private BabyRepository babyRepository;
-
-    @Autowired
-    private RelationRepository relationRepository;
-
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        public Picker<Color> picker() {
+            return colors -> Color.COLOR_1;
+        }
+    }
 }

--- a/back/src/test/java/com/baba/back/baby/domain/RelationsTest.java
+++ b/back/src/test/java/com/baba/back/baby/domain/RelationsTest.java
@@ -7,7 +7,9 @@ import static com.baba.back.fixture.DomainFixture.관계4;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.baba.back.relation.domain.RelationGroup;
+import com.baba.back.relation.domain.Relations;
 import java.util.List;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class RelationsTest {
@@ -34,5 +36,17 @@ class RelationsTest {
 
         // then
         assertThat(othersFamilyGroup).containsExactly(관계3.getRelationGroup(), 관계4.getRelationGroup());
+    }
+
+    @Test
+    void 등록된_아기가_없는_경우_그룹_조회_시_빈_리스트를_응답한다() {
+        // given
+        final Relations relations = new Relations(List.of());
+
+        // when & then
+        Assertions.assertAll(
+                () -> assertThat(relations.getMyFamilyGroup()).isEmpty(),
+                () -> assertThat(relations.getMyFamilyGroup()).isEmpty()
+        );
     }
 }

--- a/back/src/test/java/com/baba/back/baby/domain/RelationsTest.java
+++ b/back/src/test/java/com/baba/back/baby/domain/RelationsTest.java
@@ -1,13 +1,13 @@
 package com.baba.back.baby.domain;
 
 import static com.baba.back.fixture.DomainFixture.관계1;
-import static com.baba.back.fixture.DomainFixture.관계2;
 import static com.baba.back.fixture.DomainFixture.관계3;
+import static com.baba.back.fixture.DomainFixture.관계2;
+import static com.baba.back.fixture.DomainFixture.관계4;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.baba.back.relation.domain.RelationGroup;
 import java.util.List;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class RelationsTest {
@@ -15,24 +15,24 @@ class RelationsTest {
     @Test
     void 등록된_관계들_중_가족_그룹을_조회할_수_있다() {
         // given
-        final Relations relations = new Relations(List.of(관계1, 관계2, 관계3));
+        final Relations relations = new Relations(List.of(관계1, 관계2, 관계3, 관계4));
 
         // when
         final List<RelationGroup> myFamilyGroup = relations.getMyFamilyGroup();
 
         // then
-        assertThat(myFamilyGroup).containsExactly(관계1.getRelationGroup(), 관계3.getRelationGroup());
+        assertThat(myFamilyGroup).containsExactly(관계1.getRelationGroup(), 관계2.getRelationGroup());
     }
 
     @Test
     void 등록된_관계들_중_가족_그룹이_아닌_그룹을_조회할_수_있다() {
         // given
-        final Relations relations = new Relations(List.of(관계1, 관계2));
+        final Relations relations = new Relations(List.of(관계1, 관계2, 관계3, 관계4));
 
         // when
         final List<RelationGroup> othersFamilyGroup = relations.getOthersFamilyGroup();
 
         // then
-        assertThat(othersFamilyGroup).containsExactly(관계2.getRelationGroup());
+        assertThat(othersFamilyGroup).containsExactly(관계3.getRelationGroup(), 관계4.getRelationGroup());
     }
 }

--- a/back/src/test/java/com/baba/back/baby/domain/RelationsTest.java
+++ b/back/src/test/java/com/baba/back/baby/domain/RelationsTest.java
@@ -1,0 +1,38 @@
+package com.baba.back.baby.domain;
+
+import static com.baba.back.fixture.DomainFixture.관계1;
+import static com.baba.back.fixture.DomainFixture.관계2;
+import static com.baba.back.fixture.DomainFixture.관계3;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.baba.back.relation.domain.RelationGroup;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class RelationsTest {
+
+    @Test
+    void 등록된_관계들_중_가족_그룹을_조회할_수_있다() {
+        // given
+        final Relations relations = new Relations(List.of(관계1, 관계2, 관계3));
+
+        // when
+        final List<RelationGroup> myFamilyGroup = relations.getMyFamilyGroup();
+
+        // then
+        assertThat(myFamilyGroup).containsExactly(관계1.getRelationGroup(), 관계3.getRelationGroup());
+    }
+
+    @Test
+    void 등록된_관계들_중_가족_그룹이_아닌_그룹을_조회할_수_있다() {
+        // given
+        final Relations relations = new Relations(List.of(관계1, 관계2));
+
+        // when
+        final List<RelationGroup> othersFamilyGroup = relations.getOthersFamilyGroup();
+
+        // then
+        assertThat(othersFamilyGroup).containsExactly(관계2.getRelationGroup());
+    }
+}

--- a/back/src/test/java/com/baba/back/baby/service/BabyServiceTest.java
+++ b/back/src/test/java/com/baba/back/baby/service/BabyServiceTest.java
@@ -58,7 +58,7 @@ class BabyServiceTest {
     void 등록된_아기_리스트를_조회하면_가족_그룹에_해당하는_아이들과_가족_그룹이_아닌_아이들이_반환된다() {
         // given
         given(memberRepository.findById(멤버1.getId())).willReturn(Optional.of(멤버1));
-        given(relationRepository.findByMember(멤버1)).willReturn(List.of(관계2, 관계4, 관계1, 관계3));
+        given(relationRepository.findAllByMember(멤버1)).willReturn(List.of(관계2, 관계4, 관계1, 관계3));
 
        // when
         final BabiesResponse babies = babyService.findBabies(멤버1.getId());

--- a/back/src/test/java/com/baba/back/baby/service/BabyServiceTest.java
+++ b/back/src/test/java/com/baba/back/baby/service/BabyServiceTest.java
@@ -1,7 +1,31 @@
 package com.baba.back.baby.service;
 
+import static com.baba.back.fixture.DomainFixture.관계1;
+import static com.baba.back.fixture.DomainFixture.관계2;
+import static com.baba.back.fixture.DomainFixture.관계3;
+import static com.baba.back.fixture.DomainFixture.관계4;
+import static com.baba.back.fixture.DomainFixture.관계그룹1;
+import static com.baba.back.fixture.DomainFixture.관계그룹2;
+import static com.baba.back.fixture.DomainFixture.관계그룹3;
+import static com.baba.back.fixture.DomainFixture.관계그룹4;
+import static com.baba.back.fixture.DomainFixture.멤버1;
+import static com.baba.back.fixture.DomainFixture.아기1;
+import static com.baba.back.fixture.DomainFixture.아기2;
+import static com.baba.back.fixture.DomainFixture.아기3;
+import static com.baba.back.fixture.DomainFixture.아기4;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.given;
+
+import com.baba.back.baby.dto.BabiesResponse;
+import com.baba.back.baby.dto.BabyResponse;
+import com.baba.back.oauth.exception.MemberNotFoundException;
 import com.baba.back.oauth.repository.MemberRepository;
 import com.baba.back.relation.repository.RelationRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -18,4 +42,37 @@ class BabyServiceTest {
 
     @Mock
     private RelationRepository relationRepository;
+
+    @Test
+    void 존재하지_않는_멤버가_등록된_아기_리스트를_조회할_때_예외를_던진다() {
+        // given
+        final String invalidMemberId = "invalidMemberId";
+        given(memberRepository.findById(invalidMemberId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> babyService.findBabies(invalidMemberId))
+                .isInstanceOf(MemberNotFoundException.class);
+    }
+
+    @Test
+    void 등록된_아기_리스트를_조회하면_가족_그룹에_해당하는_아이들과_가족_그룹이_아닌_아이들이_반환된다() {
+        // given
+        given(memberRepository.findById(멤버1.getId())).willReturn(Optional.of(멤버1));
+        given(relationRepository.findByMember(멤버1)).willReturn(List.of(관계2, 관계4, 관계1, 관계3));
+
+       // when
+        final BabiesResponse babies = babyService.findBabies(멤버1.getId());
+
+        // then
+        assertAll(
+                () -> assertThat(babies.myBaby()).containsExactly(
+                        new BabyResponse(아기1.getId(), 관계그룹1.getGroupColor(), 아기1.getName()),
+                        new BabyResponse(아기2.getId(), 관계그룹2.getGroupColor(), 아기2.getName())
+                ),
+                () -> assertThat(babies.others()).containsExactly(
+                        new BabyResponse(아기3.getId(), 관계그룹3.getGroupColor(), 아기3.getName()),
+                        new BabyResponse(아기4.getId(), 관계그룹4.getGroupColor(), 아기4.getName())
+                )
+        );
+    }
 }

--- a/back/src/test/java/com/baba/back/content/service/ContentServiceTest.java
+++ b/back/src/test/java/com/baba/back/content/service/ContentServiceTest.java
@@ -1,7 +1,7 @@
 package com.baba.back.content.service;
 
 import static com.baba.back.fixture.DomainFixture.관계1;
-import static com.baba.back.fixture.DomainFixture.관계2;
+import static com.baba.back.fixture.DomainFixture.관계3;
 import static com.baba.back.fixture.DomainFixture.멤버1;
 import static com.baba.back.fixture.DomainFixture.아기1;
 import static com.baba.back.fixture.DomainFixture.좋아요;
@@ -107,7 +107,7 @@ class ContentServiceTest {
         // given
         given(memberRepository.findById(any())).willReturn(Optional.of(멤버1));
         given(babyRepository.findById(any())).willReturn(Optional.of(아기1));
-        given(relationRepository.findByMemberAndBaby(any(), any())).willReturn(Optional.of(관계2));
+        given(relationRepository.findByMemberAndBaby(any(), any())).willReturn(Optional.of(관계3));
 
         // when & then
         Assertions.assertThatThrownBy(() -> contentService.createContent(컨텐츠_생성_요청_데이터, MEMBER_ID, BABY_ID))

--- a/back/src/test/java/com/baba/back/fixture/DomainFixture.java
+++ b/back/src/test/java/com/baba/back/fixture/DomainFixture.java
@@ -36,6 +36,13 @@ public class DomainFixture {
             .now(LocalDate.now())
             .build();
 
+    public static final Baby 아기3 = Baby.builder()
+            .id("baby3")
+            .name("아기3")
+            .birthday(LocalDate.now())
+            .now(LocalDate.now())
+            .build();
+
     public static final RelationGroup 관계그룹1 = RelationGroup.builder()
             .baby(아기1)
             .relationGroupName("가족")
@@ -43,9 +50,15 @@ public class DomainFixture {
             .build();
 
     public static final RelationGroup 관계그룹2 = RelationGroup.builder()
-            .baby(아기1)
+            .baby(아기2)
             .relationGroupName("친구")
             .family(false)
+            .build();
+
+    public static final RelationGroup 관계그룹3 = RelationGroup.builder()
+            .baby(아기3)
+            .relationGroupName("가족")
+            .family(true)
             .build();
 
     public static final Relation 관계1 = Relation.builder()
@@ -56,8 +69,14 @@ public class DomainFixture {
 
     public static final Relation 관계2 = Relation.builder()
             .member(멤버1)
-            .relationName("아빠")
+            .relationName("아빠친구")
             .relationGroup(관계그룹2)
+            .build();
+
+    public static final Relation 관계3 = Relation.builder()
+            .member(멤버1)
+            .relationName("아빠")
+            .relationGroup(관계그룹3)
             .build();
 
     public static final Content 컨텐츠 = Content.builder()

--- a/back/src/test/java/com/baba/back/fixture/DomainFixture.java
+++ b/back/src/test/java/com/baba/back/fixture/DomainFixture.java
@@ -43,6 +43,13 @@ public class DomainFixture {
             .now(LocalDate.now())
             .build();
 
+    public static final Baby 아기4 = Baby.builder()
+            .id("baby4")
+            .name("아기4")
+            .birthday(LocalDate.now())
+            .now(LocalDate.now())
+            .build();
+
     public static final RelationGroup 관계그룹1 = RelationGroup.builder()
             .baby(아기1)
             .relationGroupName("가족")
@@ -52,15 +59,21 @@ public class DomainFixture {
 
     public static final RelationGroup 관계그룹2 = RelationGroup.builder()
             .baby(아기2)
+            .relationGroupName("가족")
+            .family(true)
+            .groupColor(Color.COLOR_1)
+            .build();
+    public static final RelationGroup 관계그룹3 = RelationGroup.builder()
+            .baby(아기3)
             .relationGroupName("친구")
             .family(false)
             .groupColor(Color.COLOR_1)
             .build();
 
-    public static final RelationGroup 관계그룹3 = RelationGroup.builder()
-            .baby(아기3)
-            .relationGroupName("가족")
-            .family(true)
+    public static final RelationGroup 관계그룹4 = RelationGroup.builder()
+            .baby(아기4)
+            .relationGroupName("외가")
+            .family(false)
             .groupColor(Color.COLOR_1)
             .build();
 
@@ -72,14 +85,20 @@ public class DomainFixture {
 
     public static final Relation 관계2 = Relation.builder()
             .member(멤버1)
-            .relationName("아빠친구")
+            .relationName("아빠")
             .relationGroup(관계그룹2)
             .build();
 
     public static final Relation 관계3 = Relation.builder()
             .member(멤버1)
-            .relationName("아빠")
+            .relationName("아빠친구")
             .relationGroup(관계그룹3)
+            .build();
+
+    public static final Relation 관계4 = Relation.builder()
+            .member(멤버1)
+            .relationName("외삼촌")
+            .relationGroup(관계그룹4)
             .build();
 
     public static final Content 컨텐츠 = Content.builder()

--- a/back/src/test/java/com/baba/back/fixture/DomainFixture.java
+++ b/back/src/test/java/com/baba/back/fixture/DomainFixture.java
@@ -47,18 +47,21 @@ public class DomainFixture {
             .baby(아기1)
             .relationGroupName("가족")
             .family(true)
+            .groupColor(Color.COLOR_1)
             .build();
 
     public static final RelationGroup 관계그룹2 = RelationGroup.builder()
             .baby(아기2)
             .relationGroupName("친구")
             .family(false)
+            .groupColor(Color.COLOR_1)
             .build();
 
     public static final RelationGroup 관계그룹3 = RelationGroup.builder()
             .baby(아기3)
             .relationGroupName("가족")
             .family(true)
+            .groupColor(Color.COLOR_1)
             .build();
 
     public static final Relation 관계1 = Relation.builder()

--- a/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
@@ -1,9 +1,9 @@
 package com.baba.back.oauth.service;
 
 import static com.baba.back.fixture.DomainFixture.관계1;
-import static com.baba.back.fixture.DomainFixture.관계2;
+import static com.baba.back.fixture.DomainFixture.관계3;
 import static com.baba.back.fixture.DomainFixture.관계그룹1;
-import static com.baba.back.fixture.DomainFixture.관계그룹2;
+import static com.baba.back.fixture.DomainFixture.관계그룹3;
 import static com.baba.back.fixture.DomainFixture.멤버1;
 import static com.baba.back.fixture.DomainFixture.아기1;
 import static com.baba.back.fixture.DomainFixture.아기2;
@@ -107,8 +107,8 @@ class MemberServiceTest {
         given(clock.instant()).willReturn(now.instant());
         given(clock.getZone()).willReturn(now.getZone());
         given(babyRepository.save(any(Baby.class))).willReturn(아기1, 아기2);
-        given(relationGroupRepository.save(any(RelationGroup.class))).willReturn(관계그룹1, 관계그룹2);
-        given(relationRepository.save(any(Relation.class))).willReturn(관계1, 관계2);
+        given(relationGroupRepository.save(any(RelationGroup.class))).willReturn(관계그룹1, 관계그룹3);
+        given(relationRepository.save(any(Relation.class))).willReturn(관계1, 관계3);
         given(accessTokenProvider.createToken(memberId)).willReturn(accessToken);
         given(refreshTokenProvider.createToken(memberId)).willReturn(refreshToken);
         given(tokenRepository.save(any(Token.class))).willReturn(any());

--- a/back/src/test/java/com/baba/back/relation/domain/RelationGroupTest.java
+++ b/back/src/test/java/com/baba/back/relation/domain/RelationGroupTest.java
@@ -19,7 +19,7 @@ class RelationGroupTest {
         assertAll(
                 () -> assertThat(relationGroup.getBabyId()).isEqualTo(아기1.getId()),
                 () -> assertThat(relationGroup.getBabyName()).isEqualTo(아기1.getName()),
-                () -> assertThat(relationGroup.getGroupColor()).isEqualTo(Color.COLOR_1.name())
+                () -> assertThat(relationGroup.getGroupColor()).isEqualTo(Color.COLOR_1.getValue())
         );
     }
 }

--- a/back/src/test/java/com/baba/back/relation/domain/RelationGroupTest.java
+++ b/back/src/test/java/com/baba/back/relation/domain/RelationGroupTest.java
@@ -1,0 +1,25 @@
+package com.baba.back.relation.domain;
+
+import static com.baba.back.fixture.DomainFixture.관계그룹1;
+import static com.baba.back.fixture.DomainFixture.아기1;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.baba.back.oauth.domain.member.Color;
+import org.junit.jupiter.api.Test;
+
+class RelationGroupTest {
+
+    @Test
+    void 관계_그룹의_정보를_조회할_수_있다() {
+        // given
+        final RelationGroup relationGroup = 관계그룹1;
+
+        // when & then
+        assertAll(
+                () -> assertThat(relationGroup.getBabyId()).isEqualTo(아기1.getId()),
+                () -> assertThat(relationGroup.getBabyName()).isEqualTo(아기1.getName()),
+                () -> assertThat(relationGroup.getGroupColor()).isEqualTo(Color.COLOR_1.name())
+        );
+    }
+}

--- a/back/src/test/java/com/baba/back/relation/repository/RelationRepositoryTest.java
+++ b/back/src/test/java/com/baba/back/relation/repository/RelationRepositoryTest.java
@@ -9,6 +9,7 @@ import com.baba.back.oauth.domain.member.Member;
 import com.baba.back.oauth.repository.MemberRepository;
 import com.baba.back.relation.domain.Relation;
 import com.baba.back.relation.domain.RelationGroup;
+import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,5 +52,29 @@ class RelationRepositoryTest {
 
         // then
         Assertions.assertThat(relation).isEqualTo(savedRelation);
+    }
+
+    @Test
+    void findByMember메소드_호출시_멤버에_등록된_relation_객체들_반환한다() {
+        // given
+        final Member savedMember = memberRepository.save(멤버1);
+        final Baby savedBaby = babyRepository.save(아기1);
+        final RelationGroup savedRelationGroup = relationGroupRepository.save(RelationGroup.builder()
+                .baby(savedBaby)
+                .relationGroupName("가족")
+                .family(true)
+                .build());
+
+        final Relation savedRelation = relationRepository.save(Relation.builder()
+                .member(savedMember)
+                .relationName("아빠")
+                .relationGroup(savedRelationGroup)
+                .build());
+
+        // when
+        final List<Relation> relation = relationRepository.findByMember(savedMember);
+
+        // then
+        Assertions.assertThat(relation).containsExactly(savedRelation);
     }
 }

--- a/back/src/test/java/com/baba/back/relation/repository/RelationRepositoryTest.java
+++ b/back/src/test/java/com/baba/back/relation/repository/RelationRepositoryTest.java
@@ -88,7 +88,7 @@ class RelationRepositoryTest {
 
 
         // when
-        final List<Relation> relation = relationRepository.findByMember(savedMember);
+        final List<Relation> relation = relationRepository.findAllByMember(savedMember);
 
         // then
         Assertions.assertThat(relation).containsExactly(savedRelation1, savedRelation2);

--- a/back/src/test/java/com/baba/back/relation/repository/RelationRepositoryTest.java
+++ b/back/src/test/java/com/baba/back/relation/repository/RelationRepositoryTest.java
@@ -2,6 +2,7 @@ package com.baba.back.relation.repository;
 
 import static com.baba.back.fixture.DomainFixture.멤버1;
 import static com.baba.back.fixture.DomainFixture.아기1;
+import static com.baba.back.fixture.DomainFixture.아기2;
 
 import com.baba.back.baby.domain.Baby;
 import com.baba.back.baby.repository.BabyRepository;
@@ -58,23 +59,38 @@ class RelationRepositoryTest {
     void findByMember메소드_호출시_멤버에_등록된_relation_객체들_반환한다() {
         // given
         final Member savedMember = memberRepository.save(멤버1);
-        final Baby savedBaby = babyRepository.save(아기1);
-        final RelationGroup savedRelationGroup = relationGroupRepository.save(RelationGroup.builder()
-                .baby(savedBaby)
+        final Baby savedBaby1 = babyRepository.save(아기1);
+        final RelationGroup savedRelationGroup1 = relationGroupRepository.save(RelationGroup.builder()
+                .baby(savedBaby1)
                 .relationGroupName("가족")
                 .family(true)
                 .build());
-
-        final Relation savedRelation = relationRepository.save(Relation.builder()
+        final Relation savedRelation1 = relationRepository.save(Relation.builder()
                 .member(savedMember)
                 .relationName("아빠")
-                .relationGroup(savedRelationGroup)
+                .relationGroup(savedRelationGroup1)
                 .build());
+
+
+        final Baby savedBaby2 = babyRepository.save(아기2);
+        final RelationGroup savedRelationGroup2 = relationGroupRepository.save(RelationGroup.builder()
+                .baby(savedBaby2)
+                .relationGroupName("친구")
+                .family(false)
+                .build());
+
+        final Relation savedRelation2 = relationRepository.save(Relation.builder()
+                .member(savedMember)
+                .relationName("아빠 친구")
+                .relationGroup(savedRelationGroup2)
+                .build());
+
+
 
         // when
         final List<Relation> relation = relationRepository.findByMember(savedMember);
 
         // then
-        Assertions.assertThat(relation).containsExactly(savedRelation);
+        Assertions.assertThat(relation).containsExactly(savedRelation1, savedRelation2);
     }
 }


### PR DESCRIPTION
## 상세 내용

등록된 아기 리스트를 조회하는 API입니다.
간단하게 구현해보았습니다.

인수테스트가 살짝 빈약합니다.
아기 초대 API 생성 후 다른 아기 추가하여 테스트 진행하도록 하겠습니다.

빠르게 진행되어야하는 상황을 감안하여 기능이 정상적으로 수행되는 지에 대해 집중하였습니다.

Close #71 