### PR TITLE
성장 앨범 메인 조회 API 를 구현한다.

### DIFF
--- a/back/src/main/java/com/baba/back/baby/domain/Baby.java
+++ b/back/src/main/java/com/baba/back/baby/domain/Baby.java
@@ -1,6 +1,6 @@
 package com.baba.back.baby.domain;
 
-import com.baba.back.oauth.domain.member.Name;
+import com.baba.back.common.domain.Name;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;

--- a/back/src/main/java/com/baba/back/common/domain/Name.java
+++ b/back/src/main/java/com/baba/back/common/domain/Name.java
@@ -1,4 +1,4 @@
-package com.baba.back.oauth.domain.member;
+package com.baba.back.common.domain;
 
 import com.baba.back.oauth.exception.NameLengthBadRequestException;
 import jakarta.persistence.Column;

--- a/back/src/main/java/com/baba/back/content/controller/ContentController.java
+++ b/back/src/main/java/com/baba/back/content/controller/ContentController.java
@@ -1,5 +1,6 @@
 package com.baba.back.content.controller;
 
+import com.baba.back.content.dto.ContentsResponse;
 import com.baba.back.content.dto.CreateContentRequest;
 import com.baba.back.content.dto.LikeContentResponse;
 import com.baba.back.content.service.ContentService;
@@ -18,9 +19,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "컨텐츠 관련 API")
@@ -56,5 +59,14 @@ public class ContentController {
                                                            @PathVariable("babyId") String babyId,
                                                            @PathVariable("contentId") Long contentId) {
         return ResponseEntity.status(HttpStatus.OK).body(contentService.likeContent(memberId, babyId, contentId));
+    }
+
+    @Operation(summary = "성장 앨범 메인 페이지 조회 요청")
+    @GetMapping()
+    public ResponseEntity<ContentsResponse> getContents(@Login String memberId,
+                                                        @PathVariable("babyId") String babyId,
+                                                        @RequestParam("year") int year,
+                                                        @RequestParam("month") int month) {
+        return ResponseEntity.ok(contentService.getContents(memberId, babyId, year, month));
     }
 }

--- a/back/src/main/java/com/baba/back/content/controller/ContentController.java
+++ b/back/src/main/java/com/baba/back/content/controller/ContentController.java
@@ -62,7 +62,7 @@ public class ContentController {
     }
 
     @Operation(summary = "성장 앨범 메인 페이지 조회 요청")
-    @GetMapping()
+    @GetMapping("/album/{babyId}")
     public ResponseEntity<ContentsResponse> getContents(@Login String memberId,
                                                         @PathVariable("babyId") String babyId,
                                                         @RequestParam("year") int year,

--- a/back/src/main/java/com/baba/back/content/controller/ContentController.java
+++ b/back/src/main/java/com/baba/back/content/controller/ContentController.java
@@ -10,6 +10,7 @@ import com.baba.back.swagger.CreatedResponse;
 import com.baba.back.swagger.ForbiddenResponse;
 import com.baba.back.swagger.IntervalServerErrorResponse;
 import com.baba.back.swagger.NotFoundResponse;
+import com.baba.back.swagger.OkResponse;
 import com.baba.back.swagger.UnAuthorizedResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -62,6 +63,10 @@ public class ContentController {
     }
 
     @Operation(summary = "성장 앨범 메인 페이지 조회 요청")
+    @OkResponse
+    @UnAuthorizedResponse
+    @NotFoundResponse
+    @IntervalServerErrorResponse
     @GetMapping("/album/{babyId}")
     public ResponseEntity<ContentsResponse> getContents(@Login String memberId,
                                                         @PathVariable("babyId") String babyId,

--- a/back/src/main/java/com/baba/back/content/domain/content/Content.java
+++ b/back/src/main/java/com/baba/back/content/domain/content/Content.java
@@ -1,7 +1,10 @@
 package com.baba.back.content.domain.content;
 
 import com.baba.back.baby.domain.Baby;
+import com.baba.back.common.domain.Name;
 import com.baba.back.oauth.domain.member.Member;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -42,14 +45,19 @@ public class Content {
     @ManyToOne(fetch = FetchType.LAZY)
     private Member owner;
 
+    @Embedded
+    @AttributeOverride(name = "value", column = @Column(name = "relation"))
+    private Name relation;
+
     @Builder
-    public Content(String title, LocalDate contentDate, LocalDate now, String cardStyle, Baby baby, Member owner) {
+    public Content(String title, LocalDate contentDate, LocalDate now, String cardStyle, Baby baby, Member owner, Name relation) {
         this.title = new Title(title);
         this.contentDate = ContentDate.of(contentDate, now, baby.getBirthday());
         this.cardStyle = CardStyle.from(cardStyle);
         this.imageSource = new ImageSource("");
         this.baby = baby;
         this.owner = owner;
+        this.relation = relation;
     }
 
     public void updateURL(String imageSource) {

--- a/back/src/main/java/com/baba/back/content/domain/content/Content.java
+++ b/back/src/main/java/com/baba/back/content/domain/content/Content.java
@@ -63,4 +63,28 @@ public class Content {
     public void updateURL(String imageSource) {
         this.imageSource = new ImageSource(imageSource);
     }
+
+    public String getOwnerName() {
+        return this.owner.getName();
+    }
+
+    public String getRelationName() {
+        return this.relation.getValue();
+    }
+
+    public LocalDate getContentDate() {
+        return this.contentDate.getValue();
+    }
+
+    public String getTitle() {
+        return this.title.getValue();
+    }
+
+    public String getImageSource() {
+        return this.imageSource.getValue();
+    }
+
+    public String getCardStyle() {
+        return this.cardStyle.name();
+    }
 }

--- a/back/src/main/java/com/baba/back/content/domain/content/ContentDate.java
+++ b/back/src/main/java/com/baba/back/content/domain/content/ContentDate.java
@@ -1,6 +1,7 @@
 package com.baba.back.content.domain.content;
 
 import com.baba.back.content.exception.ContentDateBadRequestException;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.time.LocalDate;
 import java.util.Objects;
@@ -12,10 +13,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ContentDate {
     public static final int LIMIT_YEARS = 2;
-    private LocalDate contentDate;
 
-    private ContentDate(LocalDate contentDate) {
-        this.contentDate = contentDate;
+    @Column(name = "content_date")
+    private LocalDate value;
+
+    private ContentDate(LocalDate value) {
+        this.value = value;
     }
 
     public static ContentDate of(LocalDate contentDate, LocalDate now, LocalDate baseDate) {

--- a/back/src/main/java/com/baba/back/content/domain/content/ImageSource.java
+++ b/back/src/main/java/com/baba/back/content/domain/content/ImageSource.java
@@ -1,6 +1,7 @@
 package com.baba.back.content.domain.content;
 
 import com.baba.back.content.exception.ImageSourceBadRequestException;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.util.Objects;
 import lombok.Getter;
@@ -10,11 +11,13 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class ImageSource {
-    private String imageSource;
 
-    public ImageSource(String imageSource) {
-        validateNull(imageSource);
-        this.imageSource = imageSource;
+    @Column(name = "image_source")
+    private String value;
+
+    public ImageSource(String value) {
+        validateNull(value);
+        this.value = value;
     }
 
     private void validateNull(String imageSource) {

--- a/back/src/main/java/com/baba/back/content/domain/content/Title.java
+++ b/back/src/main/java/com/baba/back/content/domain/content/Title.java
@@ -1,6 +1,7 @@
 package com.baba.back.content.domain.content;
 
 import com.baba.back.content.exception.TitleLengthBadRequestException;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.util.Objects;
 import lombok.Getter;
@@ -11,12 +12,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class Title {
     public static final int MAX_TITLE_LENGTH = 10;
-    private String title;
 
-    public Title(String title) {
-        validateNull(title);
-        validateLength(title);
-        this.title = title;
+    @Column(name = "title")
+    private String value;
+
+    public Title(String value) {
+        validateNull(value);
+        validateLength(value);
+        this.value = value;
     }
 
     private void validateNull(String title) {

--- a/back/src/main/java/com/baba/back/content/dto/ContentResponse.java
+++ b/back/src/main/java/com/baba/back/content/dto/ContentResponse.java
@@ -1,0 +1,14 @@
+package com.baba.back.content.dto;
+
+import java.time.LocalDate;
+
+public record ContentResponse(
+        Long contentId,
+        String ownerName,
+        String relation,
+        LocalDate date,
+        String title,
+        boolean like,
+        String photo,
+        String cardStyle) {
+}

--- a/back/src/main/java/com/baba/back/content/dto/ContentResponse.java
+++ b/back/src/main/java/com/baba/back/content/dto/ContentResponse.java
@@ -10,5 +10,9 @@ public record ContentResponse(
         String title,
         boolean like,
         String photo,
-        String cardStyle) {
+        String cardStyle) implements Comparable<ContentResponse> {
+    @Override
+    public int compareTo(ContentResponse o) {
+        return this.date.compareTo(o.date);
+    }
 }

--- a/back/src/main/java/com/baba/back/content/dto/ContentsResponse.java
+++ b/back/src/main/java/com/baba/back/content/dto/ContentsResponse.java
@@ -1,0 +1,6 @@
+package com.baba.back.content.dto;
+
+import java.util.List;
+
+public record ContentsResponse(List<ContentResponse> album) {
+}

--- a/back/src/main/java/com/baba/back/content/repository/ContentRepository.java
+++ b/back/src/main/java/com/baba/back/content/repository/ContentRepository.java
@@ -2,14 +2,14 @@ package com.baba.back.content.repository;
 
 import com.baba.back.baby.domain.Baby;
 import com.baba.back.content.domain.content.Content;
-import com.baba.back.content.domain.content.ContentDate;
+import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ContentRepository extends JpaRepository<Content, Long> {
-    boolean existsByContentDateAndBaby(ContentDate contentDate, Baby baby);
+    boolean existsByBabyAndContentDateValue(Baby baby, LocalDate contentDate);
 
     @Query("select c from Content c "
             + "where c.baby = :baby and year(c.contentDate.value) = :year and month(c.contentDate.value) = :month")

--- a/back/src/main/java/com/baba/back/content/repository/ContentRepository.java
+++ b/back/src/main/java/com/baba/back/content/repository/ContentRepository.java
@@ -3,8 +3,15 @@ package com.baba.back.content.repository;
 import com.baba.back.baby.domain.Baby;
 import com.baba.back.content.domain.content.Content;
 import com.baba.back.content.domain.content.ContentDate;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ContentRepository extends JpaRepository<Content, Long> {
     boolean existsByContentDateAndBaby(ContentDate contentDate, Baby baby);
+
+    @Query("select c from Content c "
+            + "where c.baby = :baby and year(c.contentDate.value) = :year and month(c.contentDate.value) = :month")
+    List<Content> findByBabyYearAndMonth(@Param("baby") Baby baby, @Param("year") int year, @Param("month") int month);
 }

--- a/back/src/main/java/com/baba/back/content/repository/LikeRepository.java
+++ b/back/src/main/java/com/baba/back/content/repository/LikeRepository.java
@@ -7,5 +7,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
-    Optional<Like> findByMemberAndContent(Member member, Content content);
+    Optional<Like> findByContentAndMember(Content content, Member member);
+
+    boolean existsByContentAndMember(Content content, Member member);
 }

--- a/back/src/main/java/com/baba/back/content/service/ContentService.java
+++ b/back/src/main/java/com/baba/back/content/service/ContentService.java
@@ -54,6 +54,7 @@ public class ContentService {
                 .cardStyle(request.getCardStyle())
                 .baby(baby)
                 .owner(member)
+                .relation(relation.getRelationName())
                 .build();
 
         checkDuplication(content.getContentDate(), baby);

--- a/back/src/main/java/com/baba/back/content/service/ContentService.java
+++ b/back/src/main/java/com/baba/back/content/service/ContentService.java
@@ -144,7 +144,9 @@ public class ContentService {
                                 likeRepository.existsByContentAndMember(content, member),
                                 content.getImageSource(),
                                 content.getCardStyle()
-                        )).toList()
+                        ))
+                        .sorted()
+                        .toList()
         );
     }
 }

--- a/back/src/main/java/com/baba/back/oauth/domain/member/Member.java
+++ b/back/src/main/java/com/baba/back/oauth/domain/member/Member.java
@@ -1,5 +1,6 @@
 package com.baba.back.oauth.domain.member;
 
+import com.baba.back.common.domain.Name;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;

--- a/back/src/main/java/com/baba/back/relation/domain/Relation.java
+++ b/back/src/main/java/com/baba/back/relation/domain/Relation.java
@@ -1,7 +1,7 @@
 package com.baba.back.relation.domain;
 
 import com.baba.back.oauth.domain.member.Member;
-import com.baba.back.oauth.domain.member.Name;
+import com.baba.back.common.domain.Name;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;

--- a/back/src/main/java/com/baba/back/relation/domain/RelationGroup.java
+++ b/back/src/main/java/com/baba/back/relation/domain/RelationGroup.java
@@ -2,7 +2,7 @@ package com.baba.back.relation.domain;
 
 import com.baba.back.baby.domain.Baby;
 import com.baba.back.oauth.domain.member.Color;
-import com.baba.back.oauth.domain.member.Name;
+import com.baba.back.common.domain.Name;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;

--- a/back/src/test/java/com/baba/back/AcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/AcceptanceTest.java
@@ -3,7 +3,6 @@ package com.baba.back;
 import static com.baba.back.SimpleRestAssured.get;
 import static com.baba.back.SimpleRestAssured.post;
 import static com.baba.back.SimpleRestAssured.thenExtract;
-import static com.baba.back.fixture.DomainFixture.멤버1;
 import static com.baba.back.fixture.RequestFixture.멤버_가입_요청_데이터;
 import static com.baba.back.fixture.RequestFixture.소셜_토큰_요청_데이터;
 
@@ -38,12 +37,12 @@ public class AcceptanceTest {
     @LocalServerPort
     int port;
 
-    protected ExtractableResponse<Response> 아기_등록_회원가입_요청_멤버_1() {
-        final String signToken = signTokenProvider.createToken(멤버1.getId());
-        return 아기_등록_회원가입_요청(signToken, 멤버_가입_요청_데이터);
+    protected ExtractableResponse<Response> 아기_등록_회원가입_요청() {
+        return 아기_등록_회원가입_요청(멤버_가입_요청_데이터);
     }
-
-    protected ExtractableResponse<Response> 아기_등록_회원가입_요청(String signToken, MemberSignUpRequest request) {
+    
+    protected ExtractableResponse<Response> 아기_등록_회원가입_요청(MemberSignUpRequest request) {
+        final String signToken = signTokenProvider.createToken("member");
         return post(MEMBER_BASE_PATH + "/baby", Map.of("Authorization", "Bearer " + signToken), request);
     }
 
@@ -67,13 +66,13 @@ public class AcceptanceTest {
         return get(BABY_BASE_PATH, Map.of("Authorization", "Bearer " + accessToken));
     }
 
-    protected ExtractableResponse<Response> 성장앨범_생성_요청(String accessToken, String babyId) {
+    protected ExtractableResponse<Response> 성장앨범_생성_요청(String accessToken, String babyId, LocalDate now) {
         return thenExtract(
                 RestAssured.given()
                         .headers(Map.of("Authorization", "Bearer " + accessToken))
                         .multiPart("photo", "test_file.jpg", "Something".getBytes(), MediaType.IMAGE_PNG_VALUE)
-                        .multiPart("date", LocalDate.now().toString())
-                        .multiPart("title", "제목")
+                        .multiPart("date", now.toString())
+                        .multiPart("title", "title")
                         .multiPart("cardStyle", "CARD_BASIC_1")
                         .when()
                         .post(CONTENT_BASE_PATH + "/" + babyId)
@@ -83,6 +82,13 @@ public class AcceptanceTest {
     protected ExtractableResponse<Response> 좋아요_요청(String accessToken, String babyId, Long contentId) {
         return post(
                 Paths.get(CONTENT_BASE_PATH, babyId, contentId.toString(), "like").toString(),
+                Map.of("Authorization", "Bearer " + accessToken)
+        );
+    }
+
+    protected ExtractableResponse<Response> 성장_앨범_메인_요청(String accessToken, String babyId, int year, int month) {
+        return get(
+                CONTENT_BASE_PATH + "/" + babyId + "?year=" + year + "&month=" + month,
                 Map.of("Authorization", "Bearer " + accessToken)
         );
     }

--- a/back/src/test/java/com/baba/back/baby/acceptance/BabyAcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/baby/acceptance/BabyAcceptanceTest.java
@@ -26,7 +26,7 @@ class BabyAcceptanceTest extends AcceptanceTest {
     @Test
     void 아기_리스트_요청_시_등록된_아기가_조회된다() {
         // given
-        final String accessToken = toObject(아기_등록_회원가입_요청_멤버_1(), MemberSignUpResponse.class).accessToken();
+        final String accessToken = toObject(아기_등록_회원가입_요청(), MemberSignUpResponse.class).accessToken();
 
         // when
         final ExtractableResponse<Response> response = 아기_리스트_조회_요청(accessToken);

--- a/back/src/test/java/com/baba/back/common/domain/NameTest.java
+++ b/back/src/test/java/com/baba/back/common/domain/NameTest.java
@@ -1,4 +1,4 @@
-package com.baba.back.oauth.domain.member;
+package com.baba.back.common.domain;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/back/src/test/java/com/baba/back/content/acceptance/ContentAcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/content/acceptance/ContentAcceptanceTest.java
@@ -172,7 +172,14 @@ public class ContentAcceptanceTest extends AcceptanceTest {
         final List<ContentResponse> album = toObject(response, ContentsResponse.class).album();
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(album).hasSize(4)
+                () -> assertThat(album).hasSize(4),
+                () -> assertThat(album.stream().map(ContentResponse::date).toList())
+                        .containsExactly(
+                                now.minusDays(3),
+                                now.minusDays(2),
+                                now.minusDays(1),
+                                now
+                        )
         );
     }
 

--- a/back/src/test/java/com/baba/back/content/acceptance/ContentAcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/content/acceptance/ContentAcceptanceTest.java
@@ -2,6 +2,7 @@ package com.baba.back.content.acceptance;
 
 import static com.baba.back.SimpleRestAssured.thenExtract;
 import static com.baba.back.SimpleRestAssured.toObject;
+import static com.baba.back.fixture.DomainFixture.now;
 import static com.baba.back.fixture.DomainFixture.아기1;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -11,6 +12,8 @@ import static org.mockito.BDDMockito.given;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.baba.back.AcceptanceTest;
+import com.baba.back.content.dto.ContentResponse;
+import com.baba.back.content.dto.ContentsResponse;
 import com.baba.back.content.dto.LikeContentResponse;
 import com.baba.back.oauth.dto.MemberSignUpResponse;
 import io.restassured.RestAssured;
@@ -19,6 +22,7 @@ import io.restassured.response.Response;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -35,7 +39,7 @@ public class ContentAcceptanceTest extends AcceptanceTest {
     @Test
     void 요청_body에_null값이_있으면_400을_던진다() {
         // given
-        final String accessToken = toObject(아기_등록_회원가입_요청_멤버_1(), MemberSignUpResponse.class).accessToken();
+        final String accessToken = toObject(아기_등록_회원가입_요청(), MemberSignUpResponse.class).accessToken();
 
         // when
         final ExtractableResponse<Response> response = thenExtract(
@@ -55,13 +59,13 @@ public class ContentAcceptanceTest extends AcceptanceTest {
     @Test
     void AWS_자체_오류로_S3에_파일_업로드_실패시_500을_던진다() {
         // given
-        final ExtractableResponse<Response> signUpResponse = 아기_등록_회원가입_요청_멤버_1();
+        final ExtractableResponse<Response> signUpResponse = 아기_등록_회원가입_요청();
         final String accessToken = toObject(signUpResponse, MemberSignUpResponse.class).accessToken();
         final String babyId = getBabyId(signUpResponse);
         given(amazonS3.putObject(any())).willThrow(AmazonServiceException.class);
 
         // when
-        final ExtractableResponse<Response> response = 성장앨범_생성_요청(accessToken, babyId);
+        final ExtractableResponse<Response> response = 성장앨범_생성_요청(accessToken, babyId, now);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
@@ -70,13 +74,13 @@ public class ContentAcceptanceTest extends AcceptanceTest {
     @Test
     void 컨텐츠를_생성한다() throws MalformedURLException {
         // given
-        final ExtractableResponse<Response> signUpResponse = 아기_등록_회원가입_요청_멤버_1();
+        final ExtractableResponse<Response> signUpResponse = 아기_등록_회원가입_요청();
         final String accessToken = toObject(signUpResponse, MemberSignUpResponse.class).accessToken();
         final String babyId = getBabyId(signUpResponse);
         given(amazonS3.getUrl(any(String.class), any(String.class))).willReturn(new URL(VALID_URL));
 
         // when
-        final ExtractableResponse<Response> response = 성장앨범_생성_요청(accessToken, babyId);
+        final ExtractableResponse<Response> response = 성장앨범_생성_요청(accessToken, babyId, now);
 
         // then
         assertAll(
@@ -89,12 +93,12 @@ public class ContentAcceptanceTest extends AcceptanceTest {
     @Test
     void 좋아요를_처음_누르면_좋아요가_추가된다() throws MalformedURLException {
         // given
-        final ExtractableResponse<Response> signUpResponse = 아기_등록_회원가입_요청_멤버_1();
+        final ExtractableResponse<Response> signUpResponse = 아기_등록_회원가입_요청();
         final String accessToken = toObject(signUpResponse, MemberSignUpResponse.class).accessToken();
         final String babyId = getBabyId(signUpResponse);
 
         given(amazonS3.getUrl(any(String.class), any(String.class))).willReturn(new URL(VALID_URL));
-        final Long contentId = getContentId(성장앨범_생성_요청(accessToken, babyId));
+        final Long contentId = getContentId(성장앨범_생성_요청(accessToken, babyId, now));
 
         // when
         final ExtractableResponse<Response> response = 좋아요_요청(accessToken, babyId, contentId);
@@ -109,11 +113,11 @@ public class ContentAcceptanceTest extends AcceptanceTest {
     @Test
     void 좋아요를_처음_누르고_한번_더_누르면_기존의_좋아요가_취소된다() throws MalformedURLException {
         // given
-        final ExtractableResponse<Response> signUpResponse = 아기_등록_회원가입_요청_멤버_1();
+        final ExtractableResponse<Response> signUpResponse = 아기_등록_회원가입_요청();
         final String accessToken = toObject(signUpResponse, MemberSignUpResponse.class).accessToken();
         final String babyId = getBabyId(signUpResponse);
         given(amazonS3.getUrl(any(String.class), any(String.class))).willReturn(new URL(VALID_URL));
-        final Long contentId = getContentId(성장앨범_생성_요청(accessToken, babyId));
+        final Long contentId = getContentId(성장앨범_생성_요청(accessToken, babyId, now));
         좋아요_요청(accessToken, babyId, contentId);
 
         // when
@@ -129,11 +133,11 @@ public class ContentAcceptanceTest extends AcceptanceTest {
     @Test
     void 좋아요를_취소하고_한번_더_누르면_다시_좋아요가_된다() throws MalformedURLException {
         // given
-        final ExtractableResponse<Response> signUpResponse = 아기_등록_회원가입_요청_멤버_1();
+        final ExtractableResponse<Response> signUpResponse = 아기_등록_회원가입_요청();
         final String accessToken = toObject(signUpResponse, MemberSignUpResponse.class).accessToken();
         final String babyId = getBabyId(signUpResponse);
         given(amazonS3.getUrl(any(String.class), any(String.class))).willReturn(new URL(VALID_URL));
-        final Long contentId = getContentId(성장앨범_생성_요청(accessToken, babyId));
+        final Long contentId = getContentId(성장앨범_생성_요청(accessToken, babyId, now));
         좋아요_요청(accessToken, babyId, contentId);
         좋아요_요청(accessToken, babyId, contentId);
 
@@ -145,5 +149,35 @@ public class ContentAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(toObject(response, LikeContentResponse.class).isLiked()).isTrue()
         );
+    }
+
+    @Test
+    void 원하는_년_월의_성장_앨범을_조회한다() throws MalformedURLException {
+        // given
+        final ExtractableResponse<Response> signUpResponse = 아기_등록_회원가입_요청();
+        final String accessToken = toObject(signUpResponse, MemberSignUpResponse.class).accessToken();
+        final String babyId = getBabyId(signUpResponse);
+        given(amazonS3.getUrl(any(String.class), any(String.class))).willReturn(new URL(VALID_URL));
+        성장앨범_생성_요청(accessToken, babyId, now);
+        성장앨범_생성_요청(accessToken, babyId, now.minusDays(1));
+        성장앨범_생성_요청(accessToken, babyId, now.minusDays(2));
+        성장앨범_생성_요청(accessToken, babyId, now.minusDays(3));
+
+        // when
+        final ExtractableResponse<Response> response = 성장_앨범_메인_요청(
+                accessToken, babyId, now.getYear(), now.getMonthValue()
+        );
+
+        // then
+        final List<ContentResponse> album = toObject(response, ContentsResponse.class).album();
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(album).hasSize(4)
+        );
+    }
+
+    // TODO: 2023/03/12 초대 로직 생성 후 테스트 작성
+    @Test
+    void 원하는_년_월의_내가_올린_성장_앨범과_다른_사람이_올린_성장_앨범을_조회한다() {
     }
 }

--- a/back/src/test/java/com/baba/back/content/domain/LikeTest.java
+++ b/back/src/test/java/com/baba/back/content/domain/LikeTest.java
@@ -2,7 +2,7 @@ package com.baba.back.content.domain;
 
 import static com.baba.back.fixture.DomainFixture.멤버1;
 import static com.baba.back.fixture.DomainFixture.아기1;
-import static com.baba.back.fixture.DomainFixture.컨텐츠;
+import static com.baba.back.fixture.DomainFixture.컨텐츠1;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.baba.back.baby.domain.Baby;
@@ -58,7 +58,7 @@ class LikeTest {
         // given
         final Like like = Like.builder()
                 .member(멤버1)
-                .content(컨텐츠)
+                .content(컨텐츠1)
                 .build();
 
         // when

--- a/back/src/test/java/com/baba/back/content/domain/LikeTest.java
+++ b/back/src/test/java/com/baba/back/content/domain/LikeTest.java
@@ -5,14 +5,12 @@ import static com.baba.back.fixture.DomainFixture.아기1;
 import static com.baba.back.fixture.DomainFixture.컨텐츠1;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.baba.back.baby.domain.Baby;
 import com.baba.back.baby.repository.BabyRepository;
 import com.baba.back.content.domain.content.Content;
 import com.baba.back.content.repository.ContentRepository;
 import com.baba.back.content.repository.LikeRepository;
 import com.baba.back.oauth.domain.member.Member;
 import com.baba.back.oauth.repository.MemberRepository;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -34,14 +32,12 @@ class LikeTest {
     private LikeRepository likeRepository;
 
     @Test
-    void 생성시간과_업데이트시간을_확인한다() {
+    void 좋아요의_생성시간과_업데이트시간을_확인한다() {
         // given
         final LocalDateTime now = LocalDateTime.now();
-        final LocalDate today = now.toLocalDate();
         final Member savedMember = memberRepository.save(멤버1);
-        final Baby savedBaby = babyRepository.save(아기1);
-        final Content savedContent = contentRepository.save(
-                new Content("제목", today, today, "CARD_BASIC_1", savedBaby, savedMember));
+        babyRepository.save(아기1);
+        final Content savedContent = contentRepository.save(컨텐츠1);
 
         // when
         final Like like = likeRepository.save(new Like(savedMember, savedContent));
@@ -54,7 +50,7 @@ class LikeTest {
     }
 
     @Test
-    void deleted가_바뀌는지_확인한다() {
+    void 좋아요의_상태가_바뀌는지_확인한다() {
         // given
         final Like like = Like.builder()
                 .member(멤버1)

--- a/back/src/test/java/com/baba/back/content/domain/content/ContentTest.java
+++ b/back/src/test/java/com/baba/back/content/domain/content/ContentTest.java
@@ -4,6 +4,7 @@ import static com.baba.back.fixture.DomainFixture.아기1;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.baba.back.baby.domain.Baby;
+import com.baba.back.common.domain.Name;
 import java.time.LocalDate;
 import java.util.UUID;
 import org.assertj.core.api.Assertions;
@@ -22,7 +23,7 @@ class ContentTest {
 
 
     @Test
-    void 컨텐츠를_생성해야_한다() {
+    void 컨텐츠를_생성할_수_있다() {
         // given
         Baby baby = Baby.builder()
                 .id(BABY_ID)
@@ -38,6 +39,7 @@ class ContentTest {
                         .now(NOW)
                         .cardStyle(CARD_STYLE)
                         .baby(baby)
+                        .relation(new Name("엄마"))
                         .build())
                 .doesNotThrowAnyException();
     }
@@ -51,6 +53,7 @@ class ContentTest {
                 .now(NOW)
                 .cardStyle(CARD_STYLE)
                 .baby(아기1)
+                .relation(new Name("엄마"))
                 .build();
 
         // when

--- a/back/src/test/java/com/baba/back/content/domain/content/ContentTest.java
+++ b/back/src/test/java/com/baba/back/content/domain/content/ContentTest.java
@@ -1,12 +1,12 @@
 package com.baba.back.content.domain.content;
 
+import static com.baba.back.fixture.DomainFixture.멤버1;
 import static com.baba.back.fixture.DomainFixture.아기1;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.baba.back.baby.domain.Baby;
 import com.baba.back.common.domain.Name;
 import java.time.LocalDate;
-import java.util.UUID;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -15,31 +15,21 @@ class ContentTest {
     public static final String TITLE = "타이틀";
     public static final LocalDate CONTENT_DATE = LocalDate.of(2023, 1, 27);
     public static final LocalDate NOW = LocalDate.of(2023, 1, 27);
-    public static final LocalDate BIRTHDAY = LocalDate.of(2023, 2, 28);
-    public static final String CARD_STYLE = "CARD_BASIC_1";
-    public static final String BABY_ID = UUID.randomUUID().toString();
-    public static final String BABY_NAME = "앙쥬";
+    public static final String CARD_STYLE = CardStyle.CARD_BASIC_1.toString();
     public static final String IMAGE_SOURCE = "1234";
 
 
     @Test
     void 컨텐츠를_생성할_수_있다() {
-        // given
-        Baby baby = Baby.builder()
-                .id(BABY_ID)
-                .name(BABY_NAME)
-                .birthday(BIRTHDAY)
-                .now(NOW)
-                .build();
-
         // when & then
         Assertions.assertThatCode(() -> Content.builder()
                         .title(TITLE)
                         .contentDate(CONTENT_DATE)
                         .now(NOW)
                         .cardStyle(CARD_STYLE)
-                        .baby(baby)
+                        .baby(아기1)
                         .relation(new Name("엄마"))
+                        .owner(멤버1)
                         .build())
                 .doesNotThrowAnyException();
     }
@@ -53,6 +43,7 @@ class ContentTest {
                 .now(NOW)
                 .cardStyle(CARD_STYLE)
                 .baby(아기1)
+                .owner(멤버1)
                 .relation(new Name("엄마"))
                 .build();
 
@@ -62,8 +53,31 @@ class ContentTest {
         // then
         assertThat(content)
                 .extracting(Content::getImageSource)
-                .isNotNull()
-                .extracting(ImageSource::getImageSource)
                 .isEqualTo(IMAGE_SOURCE);
+    }
+
+    @Test
+    void 컨텐츠에_저장된_정보를_조회할_수_있다() {
+        // given
+        final Name relationName = new Name("엄마");
+        Content content = Content.builder()
+                .title(TITLE)
+                .contentDate(CONTENT_DATE)
+                .now(NOW)
+                .cardStyle(CARD_STYLE)
+                .baby(아기1)
+                .owner(멤버1)
+                .relation(relationName)
+                .build();
+
+        // when & then
+        assertAll(
+                () -> assertThat(content.getTitle()).isEqualTo(TITLE),
+                () -> assertThat(content.getContentDate()).isEqualTo(CONTENT_DATE),
+                () -> assertThat(content.getCardStyle()).isEqualTo(CARD_STYLE),
+                () -> assertThat(content.getOwnerName()).isEqualTo(멤버1.getName()),
+                () -> assertThat(content.getRelationName()).isEqualTo(relationName.getValue()),
+                () -> assertThat(content.getImageSource()).isEmpty()
+        );
     }
 }

--- a/back/src/test/java/com/baba/back/content/repository/ContentRepositoryTest.java
+++ b/back/src/test/java/com/baba/back/content/repository/ContentRepositoryTest.java
@@ -38,7 +38,7 @@ class ContentRepositoryTest {
         contentRepository.save(컨텐츠1);
 
         // when
-        final boolean exists = contentRepository.existsByContentDateAndBaby(컨텐츠1.getContentDate(), baby);
+        final boolean exists = contentRepository.existsByBabyAndContentDateValue(baby, 컨텐츠1.getContentDate());
 
         // then
         assertThat(exists).isTrue();
@@ -51,7 +51,7 @@ class ContentRepositoryTest {
         final Baby baby = babyRepository.save(아기1);
 
         // when
-        final boolean exists = contentRepository.existsByContentDateAndBaby(컨텐츠1.getContentDate(), baby);
+        final boolean exists = contentRepository.existsByBabyAndContentDateValue(baby, 컨텐츠1.getContentDate());
 
         // then
         assertThat(exists).isFalse();
@@ -67,7 +67,7 @@ class ContentRepositoryTest {
         contentRepository.save(컨텐츠3);
         contentRepository.save(컨텐츠4);
 
-        final LocalDate now = 컨텐츠1.getContentDate().getValue();
+        final LocalDate now = 컨텐츠1.getContentDate();
 
         // when
         final List<Content> contents = contentRepository.findByBabyYearAndMonth(

--- a/back/src/test/java/com/baba/back/content/repository/ContentRepositoryTest.java
+++ b/back/src/test/java/com/baba/back/content/repository/ContentRepositoryTest.java
@@ -2,12 +2,18 @@ package com.baba.back.content.repository;
 
 import static com.baba.back.fixture.DomainFixture.멤버1;
 import static com.baba.back.fixture.DomainFixture.아기1;
-import static com.baba.back.fixture.DomainFixture.컨텐츠;
+import static com.baba.back.fixture.DomainFixture.컨텐츠1;
+import static com.baba.back.fixture.DomainFixture.컨텐츠2;
+import static com.baba.back.fixture.DomainFixture.컨텐츠3;
+import static com.baba.back.fixture.DomainFixture.컨텐츠4;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.baba.back.baby.domain.Baby;
 import com.baba.back.baby.repository.BabyRepository;
+import com.baba.back.content.domain.content.Content;
 import com.baba.back.oauth.repository.MemberRepository;
-import org.assertj.core.api.Assertions;
+import java.time.LocalDate;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -25,29 +31,73 @@ class ContentRepositoryTest {
     private ContentRepository contentRepository;
 
     @Test
-    void 해당_날짜에_이미_컨텐츠를_추가했다() {
+    void 해당_날짜에_이미_컨텐츠를_추가했는지_확인한다() {
         // given
         memberRepository.save(멤버1);
         final Baby baby = babyRepository.save(아기1);
-        contentRepository.save(컨텐츠);
+        contentRepository.save(컨텐츠1);
 
         // when
-        final boolean exists = contentRepository.existsByContentDateAndBaby(컨텐츠.getContentDate(), baby);
+        final boolean exists = contentRepository.existsByContentDateAndBaby(컨텐츠1.getContentDate(), baby);
 
         // then
-        Assertions.assertThat(exists).isTrue();
+        assertThat(exists).isTrue();
     }
 
     @Test
-    void 해당_날짜에_아직_컨텐츠가_없다() {
+    void 해당_날짜에_아직_컨텐츠가_없는지_확인한다() {
         // given
         memberRepository.save(멤버1);
         final Baby baby = babyRepository.save(아기1);
 
         // when
-        final boolean exists = contentRepository.existsByContentDateAndBaby(컨텐츠.getContentDate(), baby);
+        final boolean exists = contentRepository.existsByContentDateAndBaby(컨텐츠1.getContentDate(), baby);
 
         // then
-        Assertions.assertThat(exists).isFalse();
+        assertThat(exists).isFalse();
+    }
+
+    @Test
+    void 조회하려는_년_월에_생성된_content들을_조회한다() {
+        // given
+        final Baby baby = babyRepository.save(아기1);
+        memberRepository.save(멤버1);
+        contentRepository.save(컨텐츠1);
+        contentRepository.save(컨텐츠2);
+        contentRepository.save(컨텐츠3);
+        contentRepository.save(컨텐츠4);
+
+        final LocalDate now = 컨텐츠1.getContentDate().getValue();
+
+        // when
+        final List<Content> contents = contentRepository.findByBabyYearAndMonth(
+                baby, now.getYear(),
+                now.getMonthValue()
+        );
+
+        // then
+        assertThat(contents).hasSize(3);
+    }
+
+    @Test
+    void 조회하려는_년_월에_생성된_content들이_없다면_빈_리스트를_반환한다() {
+        // given
+        final Baby baby = babyRepository.save(아기1);
+        memberRepository.save(멤버1);
+        contentRepository.save(컨텐츠1);
+        contentRepository.save(컨텐츠2);
+        contentRepository.save(컨텐츠3);
+        contentRepository.save(컨텐츠4);
+
+        final LocalDate now = LocalDate.now().minusMonths(100);
+
+        // when
+        final List<Content> contents = contentRepository.findByBabyYearAndMonth(
+                baby, now.getYear(),
+                now.getMonthValue()
+        );
+
+        // then
+        assertThat(contents).isEmpty();
     }
 }

--- a/back/src/test/java/com/baba/back/content/repository/LikeRepositoryTest.java
+++ b/back/src/test/java/com/baba/back/content/repository/LikeRepositoryTest.java
@@ -2,15 +2,14 @@ package com.baba.back.content.repository;
 
 import static com.baba.back.fixture.DomainFixture.멤버1;
 import static com.baba.back.fixture.DomainFixture.아기1;
+import static com.baba.back.fixture.DomainFixture.컨텐츠1;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.baba.back.baby.domain.Baby;
 import com.baba.back.baby.repository.BabyRepository;
 import com.baba.back.content.domain.Like;
 import com.baba.back.content.domain.content.Content;
 import com.baba.back.oauth.domain.member.Member;
 import com.baba.back.oauth.repository.MemberRepository;
-import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -33,11 +32,9 @@ class LikeRepositoryTest {
     @Test
     void 멤버와_컨텐츠로_좋아요를_조회한다() {
         // given
-        final LocalDate now = LocalDate.now();
         final Member savedMember = memberRepository.save(멤버1);
-        final Baby savedBaby = babyRepository.save(아기1);
-        final Content savedContent = contentRepository.save(
-                new Content("제목", now, now, "CARD_BASIC_1", savedBaby, savedMember));
+        babyRepository.save(아기1);
+        final Content savedContent = contentRepository.save(컨텐츠1);
         final Like savedLike = likeRepository.save(new Like(savedMember, savedContent));
 
         // when
@@ -45,6 +42,5 @@ class LikeRepositoryTest {
 
         // then
         assertThat(savedLike).isEqualTo(findLike);
-
     }
 }

--- a/back/src/test/java/com/baba/back/content/repository/LikeRepositoryTest.java
+++ b/back/src/test/java/com/baba/back/content/repository/LikeRepositoryTest.java
@@ -38,9 +38,38 @@ class LikeRepositoryTest {
         final Like savedLike = likeRepository.save(new Like(savedMember, savedContent));
 
         // when
-        final Like findLike = likeRepository.findByMemberAndContent(savedMember, savedContent).orElseThrow();
+        final Like findLike = likeRepository.findByContentAndMember(savedContent, savedMember).orElseThrow();
 
         // then
         assertThat(savedLike).isEqualTo(findLike);
+    }
+
+    @Test
+    void 멤버가_컨텐츠에_좋아요를_눌렀는지_확인한다() {
+        // given
+        final Member savedMember = memberRepository.save(멤버1);
+        babyRepository.save(아기1);
+        final Content savedContent = contentRepository.save(컨텐츠1);
+        likeRepository.save(new Like(savedMember, savedContent));
+
+        // when
+        final boolean result = likeRepository.existsByContentAndMember(savedContent, savedMember);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void 멤버가_컨텐츠에_좋아요를_안_눌렀는지_확인한다() {
+        // given
+        final Member savedMember = memberRepository.save(멤버1);
+        babyRepository.save(아기1);
+        final Content savedContent = contentRepository.save(컨텐츠1);
+
+        // when
+        final boolean result = likeRepository.existsByContentAndMember(savedContent, savedMember);
+
+        // then
+        assertThat(result).isFalse();
     }
 }

--- a/back/src/test/java/com/baba/back/content/service/ContentServiceTest.java
+++ b/back/src/test/java/com/baba/back/content/service/ContentServiceTest.java
@@ -5,7 +5,7 @@ import static com.baba.back.fixture.DomainFixture.관계3;
 import static com.baba.back.fixture.DomainFixture.멤버1;
 import static com.baba.back.fixture.DomainFixture.아기1;
 import static com.baba.back.fixture.DomainFixture.좋아요;
-import static com.baba.back.fixture.DomainFixture.컨텐츠;
+import static com.baba.back.fixture.DomainFixture.컨텐츠1;
 import static com.baba.back.fixture.RequestFixture.컨텐츠_생성_요청_데이터;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -142,13 +142,13 @@ class ContentServiceTest {
         given(clock.getZone()).willReturn(now.getZone());
         given(contentRepository.existsByContentDateAndBaby(any(), any())).willReturn(false);
         given(fileHandler.upload(any())).willReturn("VALID_IMAGE_SOURCE");
-        given(contentRepository.save(any(Content.class))).willReturn(컨텐츠);
+        given(contentRepository.save(any(Content.class))).willReturn(컨텐츠1);
 
         // when
         final Long contentId = contentService.createContent(컨텐츠_생성_요청_데이터, MEMBER_ID, BABY_ID);
 
         // then
-        assertThat(contentId).isEqualTo(컨텐츠.getId());
+        assertThat(contentId).isEqualTo(컨텐츠1.getId());
     }
 
     @Test
@@ -157,7 +157,7 @@ class ContentServiceTest {
         given(memberRepository.findById(any())).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> contentService.likeContent(멤버1.getId(), 아기1.getId(), 컨텐츠.getId()))
+        assertThatThrownBy(() -> contentService.likeContent(멤버1.getId(), 아기1.getId(), 컨텐츠1.getId()))
                 .isInstanceOf(MemberNotFoundException.class);
     }
 
@@ -168,7 +168,7 @@ class ContentServiceTest {
         given(babyRepository.findById(any())).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> contentService.likeContent(멤버1.getId(), 아기1.getId(), 컨텐츠.getId()))
+        assertThatThrownBy(() -> contentService.likeContent(멤버1.getId(), 아기1.getId(), 컨텐츠1.getId()))
                 .isInstanceOf(BabyNotFoundException.class);
     }
 
@@ -180,7 +180,7 @@ class ContentServiceTest {
         given(relationRepository.findByMemberAndBaby(any(), any())).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> contentService.likeContent(멤버1.getId(), 아기1.getId(), 컨텐츠.getId()))
+        assertThatThrownBy(() -> contentService.likeContent(멤버1.getId(), 아기1.getId(), 컨텐츠1.getId()))
                 .isInstanceOf(RelationNotFoundException.class);
     }
 
@@ -193,7 +193,7 @@ class ContentServiceTest {
         given(contentRepository.findById(any())).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> contentService.likeContent(멤버1.getId(), 아기1.getId(), 컨텐츠.getId()))
+        assertThatThrownBy(() -> contentService.likeContent(멤버1.getId(), 아기1.getId(), 컨텐츠1.getId()))
                 .isInstanceOf(ContentNotFountException.class);
     }
 
@@ -203,12 +203,12 @@ class ContentServiceTest {
         given(memberRepository.findById(any())).willReturn(Optional.of(멤버1));
         given(babyRepository.findById(any())).willReturn(Optional.of(아기1));
         given(relationRepository.findByMemberAndBaby(any(), any())).willReturn(Optional.of(관계1));
-        given(contentRepository.findById(any())).willReturn(Optional.of(컨텐츠));
+        given(contentRepository.findById(any())).willReturn(Optional.of(컨텐츠1));
         given(likeRepository.findByMemberAndContent(any(), any())).willReturn(Optional.empty());
 
         // when
         final LikeContentResponse likeContentResponse = contentService.likeContent(멤버1.getId(), 아기1.getId(),
-                컨텐츠.getId());
+                컨텐츠1.getId());
 
         // then
         then(likeRepository).should(times(1)).save(any());
@@ -222,12 +222,12 @@ class ContentServiceTest {
         given(memberRepository.findById(any())).willReturn(Optional.of(멤버1));
         given(babyRepository.findById(any())).willReturn(Optional.of(아기1));
         given(relationRepository.findByMemberAndBaby(any(), any())).willReturn(Optional.of(관계1));
-        given(contentRepository.findById(any())).willReturn(Optional.of(컨텐츠));
+        given(contentRepository.findById(any())).willReturn(Optional.of(컨텐츠1));
         given(likeRepository.findByMemberAndContent(any(), any())).willReturn(Optional.of(좋아요));
 
         // when
         final LikeContentResponse likeContentResponse = contentService.likeContent(멤버1.getId(), 아기1.getId(),
-                컨텐츠.getId());
+                컨텐츠1.getId());
 
         // then
         then(likeRepository).should(times(1)).save(any());
@@ -241,13 +241,13 @@ class ContentServiceTest {
         given(memberRepository.findById(any())).willReturn(Optional.of(멤버1));
         given(babyRepository.findById(any())).willReturn(Optional.of(아기1));
         given(relationRepository.findByMemberAndBaby(any(), any())).willReturn(Optional.of(관계1));
-        given(contentRepository.findById(any())).willReturn(Optional.of(컨텐츠));
+        given(contentRepository.findById(any())).willReturn(Optional.of(컨텐츠1));
         given(likeRepository.findByMemberAndContent(any(), any())).willReturn(Optional.of(좋아요));
 
         // when
-        contentService.likeContent(멤버1.getId(), 아기1.getId(), 컨텐츠.getId());
+        contentService.likeContent(멤버1.getId(), 아기1.getId(), 컨텐츠1.getId());
         final LikeContentResponse likeContentResponse = contentService.likeContent(멤버1.getId(), 아기1.getId(),
-                컨텐츠.getId());
+                컨텐츠1.getId());
 
         // then
         then(likeRepository).should(times(2)).save(any());

--- a/back/src/test/java/com/baba/back/content/service/ContentServiceTest.java
+++ b/back/src/test/java/com/baba/back/content/service/ContentServiceTest.java
@@ -123,7 +123,7 @@ class ContentServiceTest {
         given(relationRepository.findByMemberAndBaby(any(), any())).willReturn(Optional.of(관계1));
         given(clock.instant()).willReturn(now.instant());
         given(clock.getZone()).willReturn(now.getZone());
-        given(contentRepository.existsByContentDateAndBaby(any(), any())).willReturn(true);
+        given(contentRepository.existsByBabyAndContentDateValue(any(), any())).willReturn(true);
 
         // when & then
         Assertions.assertThatThrownBy(() -> contentService.createContent(컨텐츠_생성_요청_데이터, MEMBER_ID, BABY_ID))
@@ -140,7 +140,7 @@ class ContentServiceTest {
         given(relationRepository.findByMemberAndBaby(any(), any())).willReturn(Optional.of(관계1));
         given(clock.instant()).willReturn(now.instant());
         given(clock.getZone()).willReturn(now.getZone());
-        given(contentRepository.existsByContentDateAndBaby(any(), any())).willReturn(false);
+        given(contentRepository.existsByBabyAndContentDateValue(any(), any())).willReturn(false);
         given(fileHandler.upload(any())).willReturn("VALID_IMAGE_SOURCE");
         given(contentRepository.save(any(Content.class))).willReturn(컨텐츠1);
 
@@ -204,7 +204,7 @@ class ContentServiceTest {
         given(babyRepository.findById(any())).willReturn(Optional.of(아기1));
         given(relationRepository.findByMemberAndBaby(any(), any())).willReturn(Optional.of(관계1));
         given(contentRepository.findById(any())).willReturn(Optional.of(컨텐츠1));
-        given(likeRepository.findByMemberAndContent(any(), any())).willReturn(Optional.empty());
+        given(likeRepository.findByContentAndMember(any(), any())).willReturn(Optional.empty());
 
         // when
         final LikeContentResponse likeContentResponse = contentService.likeContent(멤버1.getId(), 아기1.getId(),
@@ -223,7 +223,7 @@ class ContentServiceTest {
         given(babyRepository.findById(any())).willReturn(Optional.of(아기1));
         given(relationRepository.findByMemberAndBaby(any(), any())).willReturn(Optional.of(관계1));
         given(contentRepository.findById(any())).willReturn(Optional.of(컨텐츠1));
-        given(likeRepository.findByMemberAndContent(any(), any())).willReturn(Optional.of(좋아요));
+        given(likeRepository.findByContentAndMember(any(), any())).willReturn(Optional.of(좋아요));
 
         // when
         final LikeContentResponse likeContentResponse = contentService.likeContent(멤버1.getId(), 아기1.getId(),
@@ -242,7 +242,7 @@ class ContentServiceTest {
         given(babyRepository.findById(any())).willReturn(Optional.of(아기1));
         given(relationRepository.findByMemberAndBaby(any(), any())).willReturn(Optional.of(관계1));
         given(contentRepository.findById(any())).willReturn(Optional.of(컨텐츠1));
-        given(likeRepository.findByMemberAndContent(any(), any())).willReturn(Optional.of(좋아요));
+        given(likeRepository.findByContentAndMember(any(), any())).willReturn(Optional.of(좋아요));
 
         // when
         contentService.likeContent(멤버1.getId(), 아기1.getId(), 컨텐츠1.getId());

--- a/back/src/test/java/com/baba/back/content/service/ContentServiceTest.java
+++ b/back/src/test/java/com/baba/back/content/service/ContentServiceTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.times;
 import com.baba.back.baby.exception.BabyNotFoundException;
 import com.baba.back.baby.repository.BabyRepository;
 import com.baba.back.content.domain.FileHandler;
+import com.baba.back.content.domain.ImageFile;
 import com.baba.back.content.domain.content.Content;
 import com.baba.back.content.dto.ContentResponse;
 import com.baba.back.content.dto.ContentsResponse;
@@ -45,9 +46,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class ContentServiceTest {
-
-    public static final String MEMBER_ID = "1234";
-    public static final String BABY_ID = "1234";
 
     @Mock
     private ContentRepository contentRepository;
@@ -76,45 +74,45 @@ class ContentServiceTest {
     @Test
     void 멤버가_존재하지_않으면_예외를_던진다() {
         // given
-        given(memberRepository.findById(any())).willReturn(Optional.empty());
+        given(memberRepository.findById(멤버1.getId())).willReturn(Optional.empty());
 
         // when & then
-        Assertions.assertThatThrownBy(() -> contentService.createContent(컨텐츠_생성_요청_데이터, MEMBER_ID, BABY_ID))
+        Assertions.assertThatThrownBy(() -> contentService.createContent(컨텐츠_생성_요청_데이터, 멤버1.getId(), 아기1.getId()))
                 .isInstanceOf(MemberNotFoundException.class);
     }
 
     @Test
     void 아기가_존재하지_않으면_예외를_던진다() {
         // given
-        given(memberRepository.findById(any())).willReturn(Optional.of(멤버1));
-        given(babyRepository.findById(any())).willReturn(Optional.empty());
+        given(memberRepository.findById(멤버1.getId())).willReturn(Optional.of(멤버1));
+        given(babyRepository.findById(아기1.getId())).willReturn(Optional.empty());
 
         // when & then
-        Assertions.assertThatThrownBy(() -> contentService.createContent(컨텐츠_생성_요청_데이터, MEMBER_ID, BABY_ID))
+        Assertions.assertThatThrownBy(() -> contentService.createContent(컨텐츠_생성_요청_데이터, 멤버1.getId(), 아기1.getId()))
                 .isInstanceOf(BabyNotFoundException.class);
     }
 
     @Test
     void 관계가_존재하지_않으면_예외를_던진다() {
         // given
-        given(memberRepository.findById(any())).willReturn(Optional.of(멤버1));
-        given(babyRepository.findById(any())).willReturn(Optional.of(아기1));
+        given(memberRepository.findById(멤버1.getId())).willReturn(Optional.of(멤버1));
+        given(babyRepository.findById(아기1.getId())).willReturn(Optional.of(아기1));
         given(relationRepository.findByMemberAndBaby(멤버1, 아기1)).willReturn(Optional.empty());
 
         // when & then
-        Assertions.assertThatThrownBy(() -> contentService.createContent(컨텐츠_생성_요청_데이터, MEMBER_ID, BABY_ID))
+        Assertions.assertThatThrownBy(() -> contentService.createContent(컨텐츠_생성_요청_데이터, 멤버1.getId(), 아기1.getId()))
                 .isInstanceOf(RelationNotFoundException.class);
     }
 
     @Test
     void 아기의_컨텐츠를_생성할_권한이_없으면_예외를_던진다() {
         // given
-        given(memberRepository.findById(any())).willReturn(Optional.of(멤버1));
-        given(babyRepository.findById(any())).willReturn(Optional.of(아기1));
+        given(memberRepository.findById(멤버1.getId())).willReturn(Optional.of(멤버1));
+        given(babyRepository.findById(아기1.getId())).willReturn(Optional.of(아기1));
         given(relationRepository.findByMemberAndBaby(멤버1, 아기1)).willReturn(Optional.of(관계3));
 
         // when & then
-        Assertions.assertThatThrownBy(() -> contentService.createContent(컨텐츠_생성_요청_데이터, MEMBER_ID, BABY_ID))
+        Assertions.assertThatThrownBy(() -> contentService.createContent(컨텐츠_생성_요청_데이터, 멤버1.getId(), 아기1.getId()))
                 .isInstanceOf(ContentAuthorizationException.class);
     }
 
@@ -122,15 +120,15 @@ class ContentServiceTest {
     void 해당_날짜에_이미_컨텐츠가_존재하면_예외를_던진다() {
         // given
         final Clock now = Clock.systemDefaultZone();
-        given(memberRepository.findById(any())).willReturn(Optional.of(멤버1));
-        given(babyRepository.findById(any())).willReturn(Optional.of(아기1));
+        given(memberRepository.findById(멤버1.getId())).willReturn(Optional.of(멤버1));
+        given(babyRepository.findById(아기1.getId())).willReturn(Optional.of(아기1));
         given(relationRepository.findByMemberAndBaby(멤버1, 아기1)).willReturn(Optional.of(관계1));
         given(clock.instant()).willReturn(now.instant());
         given(clock.getZone()).willReturn(now.getZone());
-        given(contentRepository.existsByBabyAndContentDateValue(any(), any())).willReturn(true);
+        given(contentRepository.existsByBabyAndContentDateValue(아기1, LocalDate.now(now))).willReturn(true);
 
         // when & then
-        Assertions.assertThatThrownBy(() -> contentService.createContent(컨텐츠_생성_요청_데이터, MEMBER_ID, BABY_ID))
+        Assertions.assertThatThrownBy(() -> contentService.createContent(컨텐츠_생성_요청_데이터, 멤버1.getId(), 아기1.getId()))
                 .isInstanceOf(ContentBadRequestException.class);
     }
 
@@ -139,17 +137,17 @@ class ContentServiceTest {
         // given
         final Clock now = Clock.systemDefaultZone();
 
-        given(memberRepository.findById(any())).willReturn(Optional.of(멤버1));
-        given(babyRepository.findById(any())).willReturn(Optional.of(아기1));
-        given(relationRepository.findByMemberAndBaby(any(), any())).willReturn(Optional.of(관계1));
+        given(memberRepository.findById(멤버1.getId())).willReturn(Optional.of(멤버1));
+        given(babyRepository.findById(아기1.getId())).willReturn(Optional.of(아기1));
+        given(relationRepository.findByMemberAndBaby(멤버1, 아기1)).willReturn(Optional.of(관계1));
         given(clock.instant()).willReturn(now.instant());
         given(clock.getZone()).willReturn(now.getZone());
         given(contentRepository.existsByBabyAndContentDateValue(아기1, LocalDate.now(now))).willReturn(false);
-        given(fileHandler.upload(any())).willReturn("VALID_IMAGE_SOURCE");
+        given(fileHandler.upload(any(ImageFile.class))).willReturn("VALID_IMAGE_SOURCE");
         given(contentRepository.save(any(Content.class))).willReturn(컨텐츠1);
 
         // when
-        final Long contentId = contentService.createContent(컨텐츠_생성_요청_데이터, MEMBER_ID, BABY_ID);
+        final Long contentId = contentService.createContent(컨텐츠_생성_요청_데이터, 멤버1.getId(), 아기1.getId());
 
         // then
         assertThat(contentId).isEqualTo(컨텐츠1.getId());
@@ -179,8 +177,8 @@ class ContentServiceTest {
     @Test
     void 관계가_없으면_예외를_던진다() {
         // given
-        given(memberRepository.findById(any())).willReturn(Optional.of(멤버1));
-        given(babyRepository.findById(any())).willReturn(Optional.of(아기1));
+        given(memberRepository.findById(멤버1.getId())).willReturn(Optional.of(멤버1));
+        given(babyRepository.findById(아기1.getId())).willReturn(Optional.of(아기1));
         given(relationRepository.findByMemberAndBaby(멤버1, 아기1)).willReturn(Optional.empty());
 
         // when & then
@@ -191,10 +189,10 @@ class ContentServiceTest {
     @Test
     void 컨텐츠가_없으면_예외를_던진다() {
         // given
-        given(memberRepository.findById(any())).willReturn(Optional.of(멤버1));
-        given(babyRepository.findById(any())).willReturn(Optional.of(아기1));
+        given(memberRepository.findById(멤버1.getId())).willReturn(Optional.of(멤버1));
+        given(babyRepository.findById(아기1.getId())).willReturn(Optional.of(아기1));
         given(relationRepository.findByMemberAndBaby(멤버1, 아기1)).willReturn(Optional.of(관계1));
-        given(contentRepository.findById(any())).willReturn(Optional.empty());
+        given(contentRepository.findById(컨텐츠1.getId())).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> contentService.likeContent(멤버1.getId(), 아기1.getId(), 컨텐츠1.getId()))
@@ -204,11 +202,11 @@ class ContentServiceTest {
     @Test
     void 좋아요가_추가된다() {
         // given
-        given(memberRepository.findById(any())).willReturn(Optional.of(멤버1));
-        given(babyRepository.findById(any())).willReturn(Optional.of(아기1));
+        given(memberRepository.findById(멤버1.getId())).willReturn(Optional.of(멤버1));
+        given(babyRepository.findById(아기1.getId())).willReturn(Optional.of(아기1));
         given(relationRepository.findByMemberAndBaby(멤버1, 아기1)).willReturn(Optional.of(관계1));
-        given(contentRepository.findById(any())).willReturn(Optional.of(컨텐츠1));
-        given(likeRepository.findByContentAndMember(any(), any())).willReturn(Optional.empty());
+        given(contentRepository.findById(컨텐츠1.getId())).willReturn(Optional.of(컨텐츠1));
+        given(likeRepository.findByContentAndMember(컨텐츠1, 멤버1)).willReturn(Optional.empty());
 
         // when
         final LikeContentResponse likeContentResponse = contentService.likeContent(멤버1.getId(), 아기1.getId(),
@@ -223,11 +221,11 @@ class ContentServiceTest {
     @Test
     void 이미_좋아요가_있을때_좋아요를_누르면_기존의_좋아요가_취소된다() {
         // given
-        given(memberRepository.findById(any())).willReturn(Optional.of(멤버1));
-        given(babyRepository.findById(any())).willReturn(Optional.of(아기1));
+        given(memberRepository.findById(멤버1.getId())).willReturn(Optional.of(멤버1));
+        given(babyRepository.findById(아기1.getId())).willReturn(Optional.of(아기1));
         given(relationRepository.findByMemberAndBaby(멤버1, 아기1)).willReturn(Optional.of(관계1));
-        given(contentRepository.findById(any())).willReturn(Optional.of(컨텐츠1));
-        given(likeRepository.findByContentAndMember(any(), any())).willReturn(Optional.of(좋아요));
+        given(contentRepository.findById(컨텐츠1.getId())).willReturn(Optional.of(컨텐츠1));
+        given(likeRepository.findByContentAndMember(컨텐츠1, 멤버1)).willReturn(Optional.of(좋아요));
 
         // when
         final LikeContentResponse likeContentResponse = contentService.likeContent(멤버1.getId(), 아기1.getId(),
@@ -240,13 +238,13 @@ class ContentServiceTest {
     }
 
     @Test
-    void 좋아요를_취소하고_다시_좋아요를_누르면_deleted만_변경된다() {
+    void 좋아요를_취소하고_다시_좋아요를_누르면_좋아요가_추가된다() {
         // given
-        given(memberRepository.findById(any())).willReturn(Optional.of(멤버1));
-        given(babyRepository.findById(any())).willReturn(Optional.of(아기1));
+        given(memberRepository.findById(멤버1.getId())).willReturn(Optional.of(멤버1));
+        given(babyRepository.findById(아기1.getId())).willReturn(Optional.of(아기1));
         given(relationRepository.findByMemberAndBaby(멤버1, 아기1)).willReturn(Optional.of(관계1));
-        given(contentRepository.findById(any())).willReturn(Optional.of(컨텐츠1));
-        given(likeRepository.findByContentAndMember(any(), any())).willReturn(Optional.of(좋아요));
+        given(contentRepository.findById(컨텐츠1.getId())).willReturn(Optional.of(컨텐츠1));
+        given(likeRepository.findByContentAndMember(컨텐츠1, 멤버1)).willReturn(Optional.of(좋아요));
 
         // when
         contentService.likeContent(멤버1.getId(), 아기1.getId(), 컨텐츠1.getId());
@@ -264,9 +262,9 @@ class ContentServiceTest {
         // given
         final int year = 2023;
         final int month = 1;
-        given(memberRepository.findById(any())).willReturn(Optional.of(멤버1));
-        given(babyRepository.findById(any())).willReturn(Optional.of(아기1));
-        given(relationRepository.findByMemberAndBaby(any(), any())).willReturn(Optional.of(관계1));
+        given(memberRepository.findById(멤버1.getId())).willReturn(Optional.of(멤버1));
+        given(babyRepository.findById(아기1.getId())).willReturn(Optional.of(아기1));
+        given(relationRepository.findByMemberAndBaby(멤버1, 아기1)).willReturn(Optional.of(관계1));
         given(contentRepository.findByBabyYearAndMonth(아기1, year, month)).willReturn(List.of(컨텐츠1, 컨텐츠2));
         given(likeRepository.existsByContentAndMember(컨텐츠1, 멤버1)).willReturn(true);
         given(likeRepository.existsByContentAndMember(컨텐츠2, 멤버1)).willReturn(false);

--- a/back/src/test/java/com/baba/back/content/service/ContentServiceTest.java
+++ b/back/src/test/java/com/baba/back/content/service/ContentServiceTest.java
@@ -299,4 +299,44 @@ class ContentServiceTest {
                 )
         );
     }
+
+    @Test
+    void 없는_멤버가_성장_앨범을_조회_시_예외를_던진다() {
+        // given
+        final int year = 2023;
+        final int month = 1;
+        given(memberRepository.findById(멤버1.getId())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> contentService.getContents(멤버1.getId(), 아기1.getId(), year, month))
+                .isInstanceOf(MemberNotFoundException.class);
+    }
+
+    @Test
+    void 없는_아기의_성장_앨범을_조회_시_예외를_던진다() {
+        // given
+        final int year = 2023;
+        final int month = 1;
+        given(memberRepository.findById(멤버1.getId())).willReturn(Optional.of(멤버1));
+        given(babyRepository.findById(아기1.getId())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> contentService.getContents(멤버1.getId(), 아기1.getId(), year, month))
+                .isInstanceOf(BabyNotFoundException.class);
+    }
+
+    @Test
+    void 관계가_없는_아기의_성장_앨범을_조회_시_예외를_던진다() {
+        // given
+        final int year = 2023;
+        final int month = 1;
+        given(memberRepository.findById(멤버1.getId())).willReturn(Optional.of(멤버1));
+        given(babyRepository.findById(아기1.getId())).willReturn(Optional.of(아기1));
+        given(relationRepository.findByMemberAndBaby(멤버1, 아기1)).willReturn(Optional.empty());
+
+
+        // when & then
+        assertThatThrownBy(() -> contentService.getContents(멤버1.getId(), 아기1.getId(), year, month))
+                .isInstanceOf(RelationNotFoundException.class);
+    }
 }

--- a/back/src/test/java/com/baba/back/content/service/ContentServiceTest.java
+++ b/back/src/test/java/com/baba/back/content/service/ContentServiceTest.java
@@ -277,16 +277,6 @@ class ContentServiceTest {
                 () -> assertThat(response.album()).hasSize(2),
                 () -> assertThat(response.album()).containsExactly(
                         new ContentResponse(
-                                컨텐츠1.getId(),
-                                컨텐츠1.getOwnerName(),
-                                컨텐츠1.getRelationName(),
-                                컨텐츠1.getContentDate(),
-                                컨텐츠1.getTitle(),
-                                true,
-                                컨텐츠1.getImageSource(),
-                                컨텐츠1.getCardStyle()
-                        ),
-                        new ContentResponse(
                                 컨텐츠2.getId(),
                                 컨텐츠2.getOwnerName(),
                                 컨텐츠2.getRelationName(),
@@ -295,6 +285,16 @@ class ContentServiceTest {
                                 false,
                                 컨텐츠2.getImageSource(),
                                 컨텐츠2.getCardStyle()
+                        ),
+                        new ContentResponse(
+                                컨텐츠1.getId(),
+                                컨텐츠1.getOwnerName(),
+                                컨텐츠1.getRelationName(),
+                                컨텐츠1.getContentDate(),
+                                컨텐츠1.getTitle(),
+                                true,
+                                컨텐츠1.getImageSource(),
+                                컨텐츠1.getCardStyle()
                         )
                 )
         );

--- a/back/src/test/java/com/baba/back/fixture/DomainFixture.java
+++ b/back/src/test/java/com/baba/back/fixture/DomainFixture.java
@@ -22,27 +22,32 @@ public class DomainFixture {
             .iconName(IconName.PROFILE_G_1.toString())
             .iconColor(Color.COLOR_1)
             .build();
+
     public static final Token 토큰 = Token.builder()
             .member(멤버1)
             .value("토큰")
             .build();
+
     public static final Baby 아기1 = Baby.builder()
             .id("baby1")
             .name("아기1")
             .birthday(now)
             .now(now)
             .build();
+
     public static final RelationGroup 관계그룹1 = RelationGroup.builder()
             .baby(아기1)
             .relationGroupName("가족")
             .family(true)
             .groupColor(Color.COLOR_1)
             .build();
+
     public static final Relation 관계1 = Relation.builder()
             .member(멤버1)
             .relationName("아빠")
             .relationGroup(관계그룹1)
             .build();
+
     public static final Content 컨텐츠1 = Content.builder()
             .title("제목1")
             .contentDate(now)
@@ -50,11 +55,14 @@ public class DomainFixture {
             .cardStyle(CardStyle.CARD_BASIC_1.toString())
             .baby(아기1)
             .owner(멤버1)
+            .relation(관계1.getRelationName())
             .build();
+
     public static final Like 좋아요 = Like.builder()
             .member(멤버1)
             .content(컨텐츠1)
             .build();
+
     public static final Content 컨텐츠2 = Content.builder()
             .title("제목2")
             .contentDate(now.minusDays(1))
@@ -62,6 +70,7 @@ public class DomainFixture {
             .cardStyle(CardStyle.CARD_CANDY_1.toString())
             .baby(아기1)
             .owner(멤버1)
+            .relation(관계1.getRelationName())
             .build();
 
     public static final Content 컨텐츠3 = Content.builder()
@@ -71,7 +80,9 @@ public class DomainFixture {
             .cardStyle(CardStyle.CARD_CLOUD_2.toString())
             .baby(아기1)
             .owner(멤버1)
+            .relation(관계1.getRelationName())
             .build();
+
     public static final Content 컨텐츠4 = Content.builder()
             .title("제목4")
             .contentDate(now.minusMonths(1))
@@ -79,53 +90,63 @@ public class DomainFixture {
             .cardStyle(CardStyle.CARD_CHECK_1.toString())
             .baby(아기1)
             .owner(멤버1)
+            .relation(관계1.getRelationName())
             .build();
+
     public static final Baby 아기2 = Baby.builder()
             .id("baby2")
             .name("아기2")
             .birthday(now)
             .now(now)
             .build();
+
     public static final RelationGroup 관계그룹2 = RelationGroup.builder()
             .baby(아기2)
             .relationGroupName("가족")
             .family(true)
             .groupColor(Color.COLOR_1)
             .build();
+
     public static final Relation 관계2 = Relation.builder()
             .member(멤버1)
             .relationName("아빠")
             .relationGroup(관계그룹2)
             .build();
+
     public static final Baby 아기3 = Baby.builder()
             .id("baby3")
             .name("아기3")
             .birthday(now)
             .now(now)
             .build();
+
     public static final RelationGroup 관계그룹3 = RelationGroup.builder()
             .baby(아기3)
             .relationGroupName("친구")
             .family(false)
             .groupColor(Color.COLOR_1)
             .build();
+
     public static final Relation 관계3 = Relation.builder()
             .member(멤버1)
             .relationName("아빠친구")
             .relationGroup(관계그룹3)
             .build();
+
     public static final Baby 아기4 = Baby.builder()
             .id("baby4")
             .name("아기4")
             .birthday(now)
             .now(now)
             .build();
+
     public static final RelationGroup 관계그룹4 = RelationGroup.builder()
             .baby(아기4)
             .relationGroupName("외가")
             .family(false)
             .groupColor(Color.COLOR_1)
             .build();
+
     public static final Relation 관계4 = Relation.builder()
             .member(멤버1)
             .relationName("외삼촌")

--- a/back/src/test/java/com/baba/back/fixture/DomainFixture.java
+++ b/back/src/test/java/com/baba/back/fixture/DomainFixture.java
@@ -13,6 +13,7 @@ import com.baba.back.relation.domain.RelationGroup;
 import java.time.LocalDate;
 
 public class DomainFixture {
+    public static final LocalDate now = LocalDate.of(2023, 3, 12);
 
     public static final Member 멤버1 = Member.builder()
             .id("member1")
@@ -21,35 +22,16 @@ public class DomainFixture {
             .iconName(IconName.PROFILE_G_1.toString())
             .iconColor(Color.COLOR_1)
             .build();
-
+    public static final Token 토큰 = Token.builder()
+            .member(멤버1)
+            .value("토큰")
+            .build();
     public static final Baby 아기1 = Baby.builder()
             .id("baby1")
             .name("아기1")
-            .birthday(LocalDate.now())
-            .now(LocalDate.now())
+            .birthday(now)
+            .now(now)
             .build();
-
-    public static final Baby 아기2 = Baby.builder()
-            .id("baby2")
-            .name("아기2")
-            .birthday(LocalDate.now())
-            .now(LocalDate.now())
-            .build();
-
-    public static final Baby 아기3 = Baby.builder()
-            .id("baby3")
-            .name("아기3")
-            .birthday(LocalDate.now())
-            .now(LocalDate.now())
-            .build();
-
-    public static final Baby 아기4 = Baby.builder()
-            .id("baby4")
-            .name("아기4")
-            .birthday(LocalDate.now())
-            .now(LocalDate.now())
-            .build();
-
     public static final RelationGroup 관계그룹1 = RelationGroup.builder()
             .baby(아기1)
             .relationGroupName("가족")
@@ -60,6 +42,49 @@ public class DomainFixture {
             .member(멤버1)
             .relationName("아빠")
             .relationGroup(관계그룹1)
+            .build();
+    public static final Content 컨텐츠1 = Content.builder()
+            .title("제목1")
+            .contentDate(now)
+            .now(now)
+            .cardStyle(CardStyle.CARD_BASIC_1.toString())
+            .baby(아기1)
+            .owner(멤버1)
+            .build();
+    public static final Like 좋아요 = Like.builder()
+            .member(멤버1)
+            .content(컨텐츠1)
+            .build();
+    public static final Content 컨텐츠2 = Content.builder()
+            .title("제목2")
+            .contentDate(now.minusDays(1))
+            .now(now)
+            .cardStyle(CardStyle.CARD_CANDY_1.toString())
+            .baby(아기1)
+            .owner(멤버1)
+            .build();
+
+    public static final Content 컨텐츠3 = Content.builder()
+            .title("제목3")
+            .contentDate(now.minusDays(2))
+            .now(now)
+            .cardStyle(CardStyle.CARD_CLOUD_2.toString())
+            .baby(아기1)
+            .owner(멤버1)
+            .build();
+    public static final Content 컨텐츠4 = Content.builder()
+            .title("제목4")
+            .contentDate(now.minusMonths(1))
+            .now(now)
+            .cardStyle(CardStyle.CARD_CHECK_1.toString())
+            .baby(아기1)
+            .owner(멤버1)
+            .build();
+    public static final Baby 아기2 = Baby.builder()
+            .id("baby2")
+            .name("아기2")
+            .birthday(now)
+            .now(now)
             .build();
     public static final RelationGroup 관계그룹2 = RelationGroup.builder()
             .baby(아기2)
@@ -72,6 +97,12 @@ public class DomainFixture {
             .relationName("아빠")
             .relationGroup(관계그룹2)
             .build();
+    public static final Baby 아기3 = Baby.builder()
+            .id("baby3")
+            .name("아기3")
+            .birthday(now)
+            .now(now)
+            .build();
     public static final RelationGroup 관계그룹3 = RelationGroup.builder()
             .baby(아기3)
             .relationGroupName("친구")
@@ -83,6 +114,12 @@ public class DomainFixture {
             .relationName("아빠친구")
             .relationGroup(관계그룹3)
             .build();
+    public static final Baby 아기4 = Baby.builder()
+            .id("baby4")
+            .name("아기4")
+            .birthday(now)
+            .now(now)
+            .build();
     public static final RelationGroup 관계그룹4 = RelationGroup.builder()
             .baby(아기4)
             .relationGroupName("외가")
@@ -93,24 +130,5 @@ public class DomainFixture {
             .member(멤버1)
             .relationName("외삼촌")
             .relationGroup(관계그룹4)
-            .build();
-
-    public static final Content 컨텐츠 = Content.builder()
-            .title("제목")
-            .contentDate(LocalDate.now())
-            .now(LocalDate.now())
-            .cardStyle(CardStyle.CARD_BASIC_1.toString())
-            .baby(아기1)
-            .owner(멤버1)
-            .build();
-
-    public static final Like 좋아요 = Like.builder()
-            .member(멤버1)
-            .content(컨텐츠)
-            .build();
-
-    public static final Token 토큰 = Token.builder()
-            .member(멤버1)
-            .value("토큰")
             .build();
 }

--- a/back/src/test/java/com/baba/back/oauth/acceptance/MemberAcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/acceptance/MemberAcceptanceTest.java
@@ -1,5 +1,6 @@
 package com.baba.back.oauth.acceptance;
 
+import static com.baba.back.SimpleRestAssured.post;
 import static com.baba.back.SimpleRestAssured.toObject;
 import static com.baba.back.fixture.DomainFixture.멤버1;
 import static com.baba.back.fixture.RequestFixture.멤버_가입_요청_데이터;
@@ -19,6 +20,7 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -41,7 +43,8 @@ class MemberAcceptanceTest extends AcceptanceTest {
     @ValueSource(strings = "invalidToken")
     void 아기_등록_회원가입_요청에_유효하지_않은_sign_토큰으로_요청_시_401을_응답한다(String invalidSignToken) {
         // given
-        final ExtractableResponse<Response> response = 아기_등록_회원가입_요청(invalidSignToken, 멤버_가입_요청_데이터);
+        final ExtractableResponse<Response> response = post("/api/members/baby",
+                Map.of("Authorization", "Bearer " + invalidSignToken), 멤버_가입_요청_데이터);
 
         // when & then
         assertAll(
@@ -57,8 +60,7 @@ class MemberAcceptanceTest extends AcceptanceTest {
                 List.of(new BabyRequest("아기1", LocalDate.of(2022, 1, 1)),
                         new BabyRequest("아기2", LocalDate.of(2023, 1, 1)))
         );
-        final String signToken = signTokenProvider.createToken(MEMBER_ID);
-        final ExtractableResponse<Response> response = 아기_등록_회원가입_요청(signToken, invalidMemberSignUpRequest);
+        final ExtractableResponse<Response> response = 아기_등록_회원가입_요청(invalidMemberSignUpRequest);
 
         // when & then
         assertAll(
@@ -70,10 +72,10 @@ class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     void 아기_등록_회원가입_요청_시_이미_가입한_유저가_회원가입을_요청하면_400을_던진다() {
         // given
-        아기_등록_회원가입_요청_멤버_1();
+        아기_등록_회원가입_요청();
 
         // when
-        final ExtractableResponse<Response> response = 아기_등록_회원가입_요청_멤버_1();
+        final ExtractableResponse<Response> response = 아기_등록_회원가입_요청();
 
         //  then
         assertAll(
@@ -85,7 +87,7 @@ class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     void 아기_등록_회원가입을_진행한다() {
         // when
-        final ExtractableResponse<Response> response = 아기_등록_회원가입_요청_멤버_1();
+        final ExtractableResponse<Response> response = 아기_등록_회원가입_요청();
 
         // then
         assertAll(
@@ -99,8 +101,7 @@ class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     void 사용자_정보를_조회한다() {
         // given
-        final String signToken = signTokenProvider.createToken(멤버1.getId());
-        final ExtractableResponse<Response> 아기_등록_회원가입_응답 = 아기_등록_회원가입_요청(signToken, 멤버_가입_요청_데이터);
+        final ExtractableResponse<Response> 아기_등록_회원가입_응답 = 아기_등록_회원가입_요청(멤버_가입_요청_데이터);
         final String accessToken = toObject(아기_등록_회원가입_응답, MemberSignUpResponse.class).accessToken();
 
         // when

--- a/back/src/test/java/com/baba/back/oauth/acceptance/OAuthAcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/acceptance/OAuthAcceptanceTest.java
@@ -1,7 +1,6 @@
 package com.baba.back.oauth.acceptance;
 
 import static com.baba.back.SimpleRestAssured.toObject;
-import static com.baba.back.fixture.DomainFixture.멤버1;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
@@ -36,8 +35,8 @@ class OAuthAcceptanceTest extends AcceptanceTest {
     @Test
     void 소셜_로그인_요청_시_이미_가입되어_있으면_access_token과_refresh_token_과_200을_응답한다() {
         // given
-        아기_등록_회원가입_요청_멤버_1();
-        given(oAuthClient.getMemberId(any())).willReturn(멤버1.getId());
+        아기_등록_회원가입_요청();
+        given(oAuthClient.getMemberId(any())).willReturn("member");
 
         // when
         final ExtractableResponse<Response> response = 소셜_로그인_요청();
@@ -66,8 +65,8 @@ class OAuthAcceptanceTest extends AcceptanceTest {
     @Test
     void 약관_조회_요청_시_이미_가입되어_있으면_400을_응답한다() {
         // given
-        아기_등록_회원가입_요청_멤버_1();
-        given(oAuthClient.getMemberId(any())).willReturn(멤버1.getId());
+        아기_등록_회원가입_요청();
+        given(oAuthClient.getMemberId(any())).willReturn("member");
 
         // when
         final ExtractableResponse<Response> response = 약관_조회_요청();
@@ -94,7 +93,7 @@ class OAuthAcceptanceTest extends AcceptanceTest {
     @Test
     void 토큰_재발급_요청_시_refresh토큰의_만료기간이_하루보다_많이_남았으면_access토큰을_재발급하고_201을_응답한다() {
         // given
-        final ExtractableResponse<Response> 회원가입_응답 = 아기_등록_회원가입_요청_멤버_1();
+        final ExtractableResponse<Response> 회원가입_응답 = 아기_등록_회원가입_요청();
         final String refreshToken = toObject(회원가입_응답, MemberSignUpResponse.class).refreshToken();
         given(refreshTokenProvider.isExpiringSoon(refreshToken)).willReturn(false);
 
@@ -114,7 +113,7 @@ class OAuthAcceptanceTest extends AcceptanceTest {
     @Test
     void 토큰_재발급_요청_시_refresh토큰의_만료기간이_하루_이하로_남았으면_access토큰과_refresh토큰을_재발급하고_201을_응답한다() {
         // given
-        final ExtractableResponse<Response> 회원가입_응답 = 아기_등록_회원가입_요청_멤버_1();
+        final ExtractableResponse<Response> 회원가입_응답 = 아기_등록_회원가입_요청();
         final String refreshToken = toObject(회원가입_응답, MemberSignUpResponse.class).refreshToken();
         given(refreshTokenProvider.isExpiringSoon(refreshToken)).willReturn(true);
 


### PR DESCRIPTION
## 상세 내용
성장 앨범 메인 조회 API 를 구현하였습니다.

구현 과정에서 Content에 Name 필드를 추가하였습니다.
추가한 이유에 대해서는 [개발일지](https://granite-appeal-aa4.notion.site/Content-Relation-7f406e647c1f4f5d86902e7eb9010a49)에 작성하였습니다.

현재 구현 과정에서 콘텐츠에 대해 좋아요를 눌렀는지 안눌렀는지 판단하기위해
콘텐츠 개수만큼의 쿼리가 날라갑니다.

이 부분은 나중에서 성능 개선할 때 수정하면 좋을 것 같습니다.

Close #20 
