### PR TITLE
feat: 약관 동의 API를 구현한다.

### DIFF
--- a/back/src/main/java/com/baba/back/oauth/controller/OAuthController.java
+++ b/back/src/main/java/com/baba/back/oauth/controller/OAuthController.java
@@ -1,6 +1,8 @@
 package com.baba.back.oauth.controller;
 
+import com.baba.back.oauth.dto.AgreeTermsRequest;
 import com.baba.back.oauth.dto.SearchTermsResponse;
+import com.baba.back.oauth.dto.SignTokenResponse;
 import com.baba.back.oauth.dto.SocialLoginResponse;
 import com.baba.back.oauth.dto.SocialTokenRequest;
 import com.baba.back.oauth.dto.TokenRefreshRequest;
@@ -47,6 +49,15 @@ public class OAuthController {
     @PostMapping("/auth/login/terms")
     public ResponseEntity<SearchTermsResponse> searchTerms(@RequestBody @Valid SocialTokenRequest tokenRequest) {
         return ResponseEntity.ok().body(oauthService.searchTerms(tokenRequest));
+    }
+
+    @Operation(summary = "약관 조회 요청")
+    @OkResponse
+    @BadRequestResponse
+    @IntervalServerErrorResponse
+    @PostMapping("/auth/login/terms")
+    public ResponseEntity<SignTokenResponse> agreeTerms(@RequestBody @Valid AgreeTermsRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(oauthService.agreeTerms(request));
     }
 
     @Operation(summary = "토큰 재발급 요청")

--- a/back/src/main/java/com/baba/back/oauth/controller/OAuthController.java
+++ b/back/src/main/java/com/baba/back/oauth/controller/OAuthController.java
@@ -52,8 +52,8 @@ public class OAuthController {
         return ResponseEntity.ok().body(oauthService.searchTerms(tokenRequest));
     }
 
-    @Operation(summary = "약관 조회 요청")
-    @OkResponse
+    @Operation(summary = "약관 동의 요청")
+    @CreatedResponse
     @BadRequestResponse
     @IntervalServerErrorResponse
     @PostMapping("/auth/login/terms")

--- a/back/src/main/java/com/baba/back/oauth/domain/Terms.java
+++ b/back/src/main/java/com/baba/back/oauth/domain/Terms.java
@@ -1,6 +1,7 @@
 package com.baba.back.oauth.domain;
 
 import com.baba.back.oauth.exception.TermsBadRequestException;
+import java.util.Arrays;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -10,23 +11,22 @@ public enum Terms {
     TERMS_1(true, "이용약관 동의",
             "https://sites.google.com/view/baba-agree/%EC%9D%B4%EC%9A%A9%EC%95%BD%EA%B4%80?authuser=1"),
     TERMS_2(true, "개인정보 수집 및 이용 동의",
-            "https://sites.google.com/view/baba-agree/%EA%B0%9C%EC%9D%B8%EC%A0%95%EB%B3%B4%EC%B2%98%EB%A6%AC%EB%B0%A9%EC%B9%A8?authuser=1");
+            "https://sites.google.com/view/baba-agree/%EA%B0%9C%EC%9D%B8%EC%A0%95%EB%B3%B4%EC%B2%98%EB%A6%AC%EB%B0%A9%EC%B9%A8?authuser=1"),
+    TERMS_3(false, "앱 접근권한 허용",
+            "https://sites.google.com/view/baba-agree/%EC%95%B1-%EC%A0%91%EA%B7%BC%EA%B6%8C%ED%95%9C-%ED%97%88%EC%9A%A9?authuser=1");
 
     private final boolean required;
     private final String name;
     private final String url;
 
-    public static boolean isSameSize(int size) {
+    public static boolean isSizeEqualToAllTerms(int size) {
         return Terms.values().length == size;
     }
 
-    public static boolean isRequiredTermsBy(int idx, String name) {
-        final Terms terms = Terms.values()[idx];
-
-        if (!(terms.name).equals(name)) {
-            throw new TermsBadRequestException(idx + "번째 약관은 {" + terms.name + "}입니다.");
-        }
-
-        return terms.required;
+    public static Terms findByName(String name) {
+        return Arrays.stream(Terms.values())
+                .filter(terms -> terms.name.equals(name))
+                .findAny()
+                .orElseThrow(() -> new TermsBadRequestException("{" + name + "}은 존재하지 않는 약관입니다."));
     }
 }

--- a/back/src/main/java/com/baba/back/oauth/domain/Terms.java
+++ b/back/src/main/java/com/baba/back/oauth/domain/Terms.java
@@ -1,5 +1,6 @@
 package com.baba.back.oauth.domain;
 
+import com.baba.back.oauth.exception.TermsBadRequestException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -14,4 +15,18 @@ public enum Terms {
     private final boolean required;
     private final String name;
     private final String url;
+
+    public static boolean isSameSize(int size) {
+        return Terms.values().length == size;
+    }
+
+    public static boolean isRequiredTermsBy(int idx, String name) {
+        final Terms terms = Terms.values()[idx];
+
+        if (!(terms.name).equals(name)) {
+            throw new TermsBadRequestException(idx + "번째 약관은 {" + terms.name + "}입니다.");
+        }
+
+        return terms.required;
+    }
 }

--- a/back/src/main/java/com/baba/back/oauth/dto/AgreeTermsRequest.java
+++ b/back/src/main/java/com/baba/back/oauth/dto/AgreeTermsRequest.java
@@ -1,0 +1,19 @@
+package com.baba.back.oauth.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AgreeTermsRequest {
+
+    @NotNull
+    private String socialToken;
+
+    @NotNull
+    private List<TermsRequest> terms;
+}

--- a/back/src/main/java/com/baba/back/oauth/dto/TermsRequest.java
+++ b/back/src/main/java/com/baba/back/oauth/dto/TermsRequest.java
@@ -1,0 +1,18 @@
+package com.baba.back.oauth.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TermsRequest {
+
+    @NotNull
+    private String name;
+
+    @NotNull
+    private boolean selected;
+}

--- a/back/src/main/java/com/baba/back/oauth/exception/TermsBadRequestException.java
+++ b/back/src/main/java/com/baba/back/oauth/exception/TermsBadRequestException.java
@@ -1,0 +1,9 @@
+package com.baba.back.oauth.exception;
+
+import com.baba.back.exception.BadRequestException;
+
+public class TermsBadRequestException extends BadRequestException {
+    public TermsBadRequestException(String message) {
+        super(message);
+    }
+}

--- a/back/src/main/java/com/baba/back/oauth/service/OAuthService.java
+++ b/back/src/main/java/com/baba/back/oauth/service/OAuthService.java
@@ -79,11 +79,21 @@ public class OAuthService {
         final String memberId = oAuthClient.getMemberId(request.getSocialToken());
         validateMember(memberId);
 
-        if (!Terms.isSameSize(request.getTerms().size())) {
+        validateRequestTermsLength(request.getTerms().size());
+        validateRequestTerms(request.getTerms());
+
+        final String signToken = signTokenProvider.createToken(memberId);
+
+        return new SignTokenResponse(signToken);
+    }
+
+    private void validateRequestTermsLength(int size) {
+        if (!Terms.isSameSize(size)) {
             throw new TermsBadRequestException("요청받은 약관의 개수가 존재하는 약관의 개수와 다릅니다.");
         }
+    }
 
-        final List<TermsRequest> requestTerms = request.getTerms();
+    private void validateRequestTerms(List<TermsRequest> requestTerms) {
         for (int i = 0; i < Terms.values().length; i++) {
             final TermsRequest termsRequest = requestTerms.get(i);
             final boolean isRequiredTerms = Terms.isRequiredTermsBy(i, termsRequest.getName());
@@ -91,10 +101,6 @@ public class OAuthService {
                 throw new TermsBadRequestException("필수 동의 약관을 모두 동의하지 않았습니다.");
             }
         }
-
-        final String signToken = signTokenProvider.createToken(memberId);
-
-        return new SignTokenResponse(signToken);
     }
 
     public TokenRefreshResponse refresh(TokenRefreshRequest request) {

--- a/back/src/main/java/com/baba/back/oauth/service/OAuthService.java
+++ b/back/src/main/java/com/baba/back/oauth/service/OAuthService.java
@@ -81,8 +81,9 @@ public class OAuthService {
         final String memberId = oAuthClient.getMemberId(request.getSocialToken());
         validateMember(memberId);
 
-        final Set<Terms> selectedTerms = findValidTerms(request.getTerms());
-        validateDuplicate(request.getTerms().size(), selectedTerms.size());
+        final List<TermsRequest> requestTerms = request.getTerms();
+        final Set<Terms> selectedTerms = findValidTerms(requestTerms);
+        validateDuplicate(requestTerms.size(), selectedTerms.size());
         validateSelectedTerms(selectedTerms.size());
 
         final String signToken = signTokenProvider.createToken(memberId);

--- a/back/src/main/java/com/baba/back/oauth/service/OAuthService.java
+++ b/back/src/main/java/com/baba/back/oauth/service/OAuthService.java
@@ -84,10 +84,10 @@ public class OAuthService {
         }
 
         final List<TermsRequest> requestTerms = request.getTerms();
-        for(int i=0; i<Terms.values().length; i++) {
+        for (int i = 0; i < Terms.values().length; i++) {
             final TermsRequest termsRequest = requestTerms.get(i);
             final boolean isRequiredTerms = Terms.isRequiredTermsBy(i, termsRequest.getName());
-            if(isRequiredTerms && !termsRequest.isSelected()) {
+            if (isRequiredTerms && !termsRequest.isSelected()) {
                 throw new TermsBadRequestException("필수 동의 약관을 모두 동의하지 않았습니다.");
             }
         }

--- a/back/src/main/java/com/baba/back/oauth/service/OAuthService.java
+++ b/back/src/main/java/com/baba/back/oauth/service/OAuthService.java
@@ -4,19 +4,24 @@ import com.baba.back.oauth.OAuthClient;
 import com.baba.back.oauth.domain.Terms;
 import com.baba.back.oauth.domain.member.Member;
 import com.baba.back.oauth.domain.token.Token;
+import com.baba.back.oauth.dto.AgreeTermsRequest;
 import com.baba.back.oauth.dto.SearchTermsResponse;
+import com.baba.back.oauth.dto.SignTokenResponse;
 import com.baba.back.oauth.dto.SocialLoginResponse;
 import com.baba.back.oauth.dto.SocialTokenRequest;
+import com.baba.back.oauth.dto.TermsRequest;
 import com.baba.back.oauth.dto.TermsResponse;
 import com.baba.back.oauth.dto.TokenRefreshRequest;
 import com.baba.back.oauth.dto.TokenRefreshResponse;
 import com.baba.back.oauth.exception.MemberBadRequestException;
 import com.baba.back.oauth.exception.MemberNotFoundException;
+import com.baba.back.oauth.exception.TermsBadRequestException;
 import com.baba.back.oauth.exception.TokenBadRequestException;
 import com.baba.back.oauth.repository.MemberRepository;
 import com.baba.back.oauth.repository.TokenRepository;
 import jakarta.transaction.Transactional;
 import java.util.Arrays;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -35,6 +40,7 @@ public class OAuthService {
     private final OAuthClient oAuthClient;
     private final AccessTokenProvider accessTokenProvider;
     private final RefreshTokenProvider refreshTokenProvider;
+    private final SignTokenProvider signTokenProvider;
     private final MemberRepository memberRepository;
     private final TokenRepository tokenRepository;
 
@@ -67,6 +73,28 @@ public class OAuthService {
         if (memberRepository.existsById(memberId)) {
             throw new MemberBadRequestException("이미 회원가입된 유저는 약관을 조회할 수 없습니다.");
         }
+    }
+
+    public SignTokenResponse agreeTerms(AgreeTermsRequest request) {
+        final String memberId = oAuthClient.getMemberId(request.getSocialToken());
+        validateMember(memberId);
+
+        if (!Terms.isSameSize(request.getTerms().size())) {
+            throw new TermsBadRequestException("요청받은 약관의 개수가 존재하는 약관의 개수와 다릅니다.");
+        }
+
+        final List<TermsRequest> requestTerms = request.getTerms();
+        for(int i=0; i<Terms.values().length; i++) {
+            final TermsRequest termsRequest = requestTerms.get(i);
+            final boolean isRequiredTerms = Terms.isRequiredTermsBy(i, termsRequest.getName());
+            if(isRequiredTerms && !termsRequest.isSelected()) {
+                throw new TermsBadRequestException("필수 동의 약관을 모두 동의하지 않았습니다.");
+            }
+        }
+
+        final String signToken = signTokenProvider.createToken(memberId);
+
+        return new SignTokenResponse(signToken);
     }
 
     public TokenRefreshResponse refresh(TokenRefreshRequest request) {

--- a/back/src/main/resources/logback-spring.xml
+++ b/back/src/main/resources/logback-spring.xml
@@ -29,7 +29,8 @@
                 <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-3relative][%thread] %-5level %logger{35} - %msg%n</pattern>
             </encoder>
             <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                <fileNamePattern>${LOGS_ABSOLUTE_PATH}/${PROFILE}/logs/was-logs/info.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+                <fileNamePattern>${LOGS_ABSOLUTE_PATH}/${PROFILE}/logs/was-logs/info.%d{yyyy-MM-dd}.%i.log.gz
+                </fileNamePattern>
                 <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
                     <maxFileSize>100MB</maxFileSize>
                 </timeBasedFileNamingAndTriggeringPolicy>
@@ -48,7 +49,8 @@
                 <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-3relative][%thread] %-5level %logger{35} - %msg%n</pattern>
             </encoder>
             <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                <fileNamePattern>${LOGS_ABSOLUTE_PATH}/${PROFILE}/logs/was-logs/warn.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+                <fileNamePattern>${LOGS_ABSOLUTE_PATH}/${PROFILE}/logs/was-logs/warn.%d{yyyy-MM-dd}.%i.log.gz
+                </fileNamePattern>
                 <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
                     <maxFileSize>100MB</maxFileSize>
                 </timeBasedFileNamingAndTriggeringPolicy>
@@ -67,7 +69,8 @@
                 <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-3relative][%thread] %-5level %logger{35} - %msg%n</pattern>
             </encoder>
             <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                <fileNamePattern>${LOGS_ABSOLUTE_PATH}/${PROFILE}/logs/was-logs/error.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+                <fileNamePattern>${LOGS_ABSOLUTE_PATH}/${PROFILE}/logs/was-logs/error.%d{yyyy-MM-dd}.%i.log.gz
+                </fileNamePattern>
                 <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
                     <maxFileSize>100MB</maxFileSize>
                 </timeBasedFileNamingAndTriggeringPolicy>

--- a/back/src/test/java/com/baba/back/AcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/AcceptanceTest.java
@@ -6,6 +6,7 @@ import static com.baba.back.SimpleRestAssured.thenExtract;
 import static com.baba.back.fixture.DomainFixture.멤버1;
 import static com.baba.back.fixture.RequestFixture.멤버_가입_요청_데이터;
 import static com.baba.back.fixture.RequestFixture.소셜_토큰_요청_데이터;
+import static com.baba.back.fixture.RequestFixture.약관_동의_요청_데이터;
 
 import com.baba.back.oauth.dto.MemberSignUpRequest;
 import com.baba.back.oauth.dto.TokenRefreshRequest;
@@ -57,6 +58,10 @@ public class AcceptanceTest {
 
     protected ExtractableResponse<Response> 약관_조회_요청() {
         return post(AUTH_BASE_PATH + "/login/terms", 소셜_토큰_요청_데이터);
+    }
+
+    protected ExtractableResponse<Response> 약관_동의_요청() {
+        return post(AUTH_BASE_PATH + "/login/terms", 약관_동의_요청_데이터);
     }
 
     protected ExtractableResponse<Response> 토큰_재발급_요청(TokenRefreshRequest request) {

--- a/back/src/test/java/com/baba/back/fixture/RequestFixture.java
+++ b/back/src/test/java/com/baba/back/fixture/RequestFixture.java
@@ -4,6 +4,7 @@ import static com.baba.back.content.domain.content.CardStyle.CARD_BASIC_1;
 
 import com.baba.back.baby.dto.BabyRequest;
 import com.baba.back.content.dto.CreateContentRequest;
+import com.baba.back.oauth.domain.Terms;
 import com.baba.back.oauth.dto.AgreeTermsRequest;
 import com.baba.back.oauth.dto.MemberSignUpRequest;
 import com.baba.back.oauth.dto.SocialTokenRequest;
@@ -14,10 +15,11 @@ import org.springframework.mock.web.MockMultipartFile;
 
 public class RequestFixture {
 
-    public static final TermsRequest 약관_요청_데이터1 = new TermsRequest("이용약관 동의", true);
-    public static final TermsRequest 약관_요청_데이터2 = new TermsRequest("개인정보 수집 및 이용 동의", true);
+    public static final TermsRequest 약관_요청_데이터1 = new TermsRequest(Terms.TERMS_1.getName(), true);
+    public static final TermsRequest 약관_요청_데이터2 = new TermsRequest(Terms.TERMS_2.getName(), true);
+    public static final TermsRequest 약관_요청_데이터3 = new TermsRequest(Terms.TERMS_3.getName(), true);
     public static final AgreeTermsRequest 약관_동의_요청_데이터 = new AgreeTermsRequest(
-            "socialToken", List.of(약관_요청_데이터1, 약관_요청_데이터2)
+            "socialToken", List.of(약관_요청_데이터1, 약관_요청_데이터2, 약관_요청_데이터3)
     );
 
     public static final BabyRequest 아기_생성_요청_데이터_1 = new BabyRequest("아기1", LocalDate.now());

--- a/back/src/test/java/com/baba/back/fixture/RequestFixture.java
+++ b/back/src/test/java/com/baba/back/fixture/RequestFixture.java
@@ -4,18 +4,26 @@ import static com.baba.back.content.domain.content.CardStyle.CARD_BASIC_1;
 
 import com.baba.back.baby.dto.BabyRequest;
 import com.baba.back.content.dto.CreateContentRequest;
+import com.baba.back.oauth.dto.AgreeTermsRequest;
 import com.baba.back.oauth.dto.MemberSignUpRequest;
 import com.baba.back.oauth.dto.SocialTokenRequest;
+import com.baba.back.oauth.dto.TermsRequest;
 import java.time.LocalDate;
 import java.util.List;
 import org.springframework.mock.web.MockMultipartFile;
 
 public class RequestFixture {
 
-    public static final BabyRequest 아기_생성_요청_데아터_1 = new BabyRequest("아기1", LocalDate.now());
+    public static final TermsRequest 약관_요청_데이터1 = new TermsRequest("이용약관 동의", true);
+    public static final TermsRequest 약관_요청_데이터2 = new TermsRequest("개인정보 수집 및 이용 동의", true);
+    public static final AgreeTermsRequest 약관_동의_요청_데이터 = new AgreeTermsRequest(
+            "socialToken", List.of(약관_요청_데이터1, 약관_요청_데이터2)
+    );
+
+    public static final BabyRequest 아기_생성_요청_데이터_1 = new BabyRequest("아기1", LocalDate.now());
     public static final BabyRequest 아기_생성_요청_데이터_2 = new BabyRequest("아기2", LocalDate.now());
     public static final MemberSignUpRequest 멤버_가입_요청_데이터 = new MemberSignUpRequest(
-            "박재희", "PROFILE_W_1", "엄마", List.of(아기_생성_요청_데아터_1, 아기_생성_요청_데이터_2)
+            "박재희", "PROFILE_W_1", "엄마", List.of(아기_생성_요청_데이터_1, 아기_생성_요청_데이터_2)
     );
 
     public static final SocialTokenRequest 소셜_토큰_요청_데이터 = new SocialTokenRequest("socialToken");

--- a/back/src/test/java/com/baba/back/oauth/acceptance/OAuthAcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/acceptance/OAuthAcceptanceTest.java
@@ -14,6 +14,7 @@ import com.baba.back.oauth.OAuthClient;
 import com.baba.back.oauth.domain.Terms;
 import com.baba.back.oauth.dto.MemberSignUpResponse;
 import com.baba.back.oauth.dto.SearchTermsResponse;
+import com.baba.back.oauth.dto.SignTokenResponse;
 import com.baba.back.oauth.dto.SocialLoginResponse;
 import com.baba.back.oauth.dto.TokenRefreshRequest;
 import com.baba.back.oauth.dto.TokenRefreshResponse;
@@ -102,6 +103,21 @@ class OAuthAcceptanceTest extends AcceptanceTest {
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    void 약관_동의_요청_시_sign_token과_201을_응답한다() {
+        // given
+        given(oAuthClient.getMemberId(any())).willReturn(멤버1.getId());
+
+        // when
+        final ExtractableResponse<Response> response = 약관_동의_요청();
+
+        // then
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
+                () -> assertThat(toObject(response, SignTokenResponse.class).signToken()).isNotBlank()
+        );
     }
 
     @Test

--- a/back/src/test/java/com/baba/back/oauth/acceptance/OAuthAcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/acceptance/OAuthAcceptanceTest.java
@@ -92,6 +92,19 @@ class OAuthAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
+    void 약관_동의_요청_시_이미_가입되어_있으면_400을_응답한다() {
+        // given
+        아기_등록_회원가입_요청_멤버_1();
+        given(oAuthClient.getMemberId(any())).willReturn(멤버1.getId());
+
+        // when
+        final ExtractableResponse<Response> response = 약관_동의_요청();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
     void 토큰_재발급_요청_시_refresh토큰의_만료기간이_하루보다_많이_남았으면_access토큰을_재발급하고_201을_응답한다() {
         // given
         final ExtractableResponse<Response> 회원가입_응답 = 아기_등록_회원가입_요청_멤버_1();

--- a/back/src/test/java/com/baba/back/oauth/domain/TermsTest.java
+++ b/back/src/test/java/com/baba/back/oauth/domain/TermsTest.java
@@ -8,36 +8,40 @@ import org.junit.jupiter.api.Test;
 
 class TermsTest {
 
+    public static final int REQUIRED_TERMS_LENGTH = 2;
+    public static final int ALL_TERMS_LENGTH = Terms.values().length;
+
     @Test
-    void 약관의_개수가_다르면_false를_반환한다() {
+    void 모든_약관의_개수가_다르면_false를_반환한다() {
         // given & when
-        final boolean sameSize = Terms.isSameSize(Terms.values().length - 1);
+        final boolean sameSize = Terms.isSizeEqualToAllTerms(REQUIRED_TERMS_LENGTH);
 
         // then
         assertThat(sameSize).isFalse();
     }
 
     @Test
-    void 약관의_개수가_같으면_true를_반환한다() {
+    void 모든_약관의_개수가_같으면_true를_반환한다() {
         // given & when
-        final boolean sameSize = Terms.isSameSize(Terms.values().length);
+        final boolean sameSize = Terms.isSizeEqualToAllTerms(ALL_TERMS_LENGTH);
 
         // then
         assertThat(sameSize).isTrue();
     }
 
     @Test
-    void N번째_약관과_이름이_다르다면_예외를_던진다() {
-        assertThatThrownBy(() -> Terms.isRequiredTermsBy(0, Terms.TERMS_2.getName()))
+    void 요청받은_이름의_약관이_존재하지_않으면_예외를_던진다() {
+        // given
+        final String invalidTermsName = "존재하지 않은 약관";
+
+        // when & then
+        assertThatThrownBy(() -> Terms.findByName(invalidTermsName))
                 .isInstanceOf(TermsBadRequestException.class);
     }
 
     @Test
-    void N번째_약관과_이름이_같다면_약관의_필수여부를_반환한다() {
-        // given
-        final boolean requiredTerms = Terms.isRequiredTermsBy(0, Terms.TERMS_1.getName());
-
-        assertThat(requiredTerms).isEqualTo(Terms.TERMS_1.isRequired());
+    void 요청받은_이름의_약관이_존재하면_약관을_반환한다() {
+        assertThat(Terms.findByName(Terms.TERMS_2.getName())).isEqualTo(Terms.TERMS_2);
     }
 
 

--- a/back/src/test/java/com/baba/back/oauth/domain/TermsTest.java
+++ b/back/src/test/java/com/baba/back/oauth/domain/TermsTest.java
@@ -1,0 +1,44 @@
+package com.baba.back.oauth.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.baba.back.oauth.exception.TermsBadRequestException;
+import org.junit.jupiter.api.Test;
+
+class TermsTest {
+
+    @Test
+    void 약관의_개수가_다르면_false를_반환한다() {
+        // given & when
+        final boolean sameSize = Terms.isSameSize(Terms.values().length - 1);
+
+        // then
+        assertThat(sameSize).isFalse();
+    }
+
+    @Test
+    void 약관의_개수가_같으면_true를_반환한다() {
+        // given & when
+        final boolean sameSize = Terms.isSameSize(Terms.values().length);
+
+        // then
+        assertThat(sameSize).isTrue();
+    }
+
+    @Test
+    void N번째_약관과_이름이_다르다면_예외를_던진다() {
+        assertThatThrownBy(() -> Terms.isRequiredTermsBy(0, Terms.TERMS_2.getName()))
+                .isInstanceOf(TermsBadRequestException.class);
+    }
+
+    @Test
+    void N번째_약관과_이름이_같다면_약관의_필수여부를_반환한다() {
+        // given
+        final boolean requiredTerms = Terms.isRequiredTermsBy(0, Terms.TERMS_1.getName());
+
+        assertThat(requiredTerms).isEqualTo(Terms.TERMS_1.isRequired());
+    }
+
+
+}

--- a/back/src/test/java/com/baba/back/oauth/domain/TermsTest.java
+++ b/back/src/test/java/com/baba/back/oauth/domain/TermsTest.java
@@ -8,13 +8,12 @@ import org.junit.jupiter.api.Test;
 
 class TermsTest {
 
-    public static final int REQUIRED_TERMS_LENGTH = 2;
     public static final int ALL_TERMS_LENGTH = Terms.values().length;
 
     @Test
     void 모든_약관의_개수가_다르면_false를_반환한다() {
         // given & when
-        final boolean sameSize = Terms.isSizeEqualToAllTerms(REQUIRED_TERMS_LENGTH);
+        final boolean sameSize = Terms.isSizeEqualToAllTerms(ALL_TERMS_LENGTH - 1);
 
         // then
         assertThat(sameSize).isFalse();

--- a/back/src/test/java/com/baba/back/oauth/service/OAuthServiceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/service/OAuthServiceTest.java
@@ -281,10 +281,10 @@ class OAuthServiceTest {
             final String signToken = "signToken";
             given(oAuthClient.getMemberId(any())).willReturn(멤버1.getId());
             given(memberRepository.existsById(멤버1.getId())).willReturn(false);
-            mockedTerms.when(Terms::values).thenReturn(values);
-            mockedTerms.when(() -> Terms.isSameSize(values.length)).thenReturn(true);
-            mockedTerms.when(() -> Terms.isRequiredTermsBy(0, Terms.TERMS_1.getName())).thenReturn(true);
-            mockedTerms.when(() -> Terms.isRequiredTermsBy(1, Terms.TERMS_2.getName())).thenReturn(false);
+            given(Terms.values()).willReturn(values);
+            given(Terms.isSameSize(values.length)).willReturn(true);
+            given(Terms.isRequiredTermsBy(0, Terms.TERMS_1.getName())).willReturn(true);
+            given(Terms.isRequiredTermsBy(0, Terms.TERMS_2.getName())).willReturn(false);
             given(signTokenProvider.createToken(멤버1.getId())).willReturn(signToken);
 
             // when

--- a/back/src/test/java/com/baba/back/oauth/service/OAuthServiceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/service/OAuthServiceTest.java
@@ -216,9 +216,9 @@ class OAuthServiceTest {
     @Test
     void 약관_동의_요청시_잘못된_약관이_존재하면_예외를_던진다() {
         // given
-        final String invalidToken = "invalidToken";
+        final String validToken = "validToken";
         final String invalidTermsName = "invalidTermsName";
-        final AgreeTermsRequest request = new AgreeTermsRequest(invalidToken,
+        final AgreeTermsRequest request = new AgreeTermsRequest(validToken,
                 List.of(new TermsRequest(Terms.TERMS_1.getName(), true),
                         new TermsRequest(Terms.TERMS_2.getName(), true),
                         new TermsRequest(invalidTermsName, true)));
@@ -233,8 +233,8 @@ class OAuthServiceTest {
     @Test
     void 약관_동의_요청시_모든_필수_동의_약관을_동의하지_않았으면_예외를_던진다() {
         // given
-        final String invalidToken = "invalidToken";
-        final AgreeTermsRequest request = new AgreeTermsRequest(invalidToken,
+        final String validToken = "validToken";
+        final AgreeTermsRequest request = new AgreeTermsRequest(validToken,
                 List.of(new TermsRequest(Terms.TERMS_1.getName(), true),
                         new TermsRequest(Terms.TERMS_2.getName(), false),
                         new TermsRequest(Terms.TERMS_3.getName(), false)));
@@ -249,8 +249,8 @@ class OAuthServiceTest {
     @Test
     void 약관_동의_요청시_중복된_약관이_존재하면_예외를_던진다() {
         // given
-        final String invalidToken = "invalidToken";
-        final AgreeTermsRequest request = new AgreeTermsRequest(invalidToken,
+        final String validToken = "validToken";
+        final AgreeTermsRequest request = new AgreeTermsRequest(validToken,
                 List.of(new TermsRequest(Terms.TERMS_1.getName(), true),
                         new TermsRequest(Terms.TERMS_1.getName(), true),
                         new TermsRequest(Terms.TERMS_2.getName(), true),
@@ -266,8 +266,8 @@ class OAuthServiceTest {
     @Test
     void 약관_동의_요청시_생략된_약관이_존재하면_예외를_던진다() {
         // given
-        final String invalidToken = "invalidToken";
-        final AgreeTermsRequest request = new AgreeTermsRequest(invalidToken,
+        final String validToken = "validToken";
+        final AgreeTermsRequest request = new AgreeTermsRequest(validToken,
                 List.of(new TermsRequest(Terms.TERMS_1.getName(), true),
                         new TermsRequest(Terms.TERMS_2.getName(), true)));
         given(oAuthClient.getMemberId(any())).willReturn(멤버1.getId());

--- a/back/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/back/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/back/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/back/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
## 상세 내용
필수가 아닌 약관을 테스트하는 방법에 대해 고민하느라 늦었습니다.
[baeldung](https://www.baeldung.com/mockito-mock-static-methods) 사이트를 참고해 `Terms` enum 클래스의 static 메소드를 `mockStatic`으로 모킹하는 방식으로 문제를 해결했습니다.

mockStatic을 사용하기 위해 `src/test/resources/mockito-extensions`에 `org.mockito.plugins.MockMaker` 파일을 추가했는데, `Sharing is only supported for boot loader classes because bootstrap classpath has been appended`의 경고 메시지가 뜨네요. 
mockito 깃헙에서 해당 메시지를 무시해도 된다는 내용을 확인했습니다. ([링크](https://github.com/mockito/mockito/issues/2590))

> 선택 약관이 추가되어 mockStatic을 사용할 필요가 없어졌습니다. 다만 테스트가 `Terms` enum 클래스의 값에 의존하여 만약 선택 약관이 삭제되면 테스트 커버리지 100%가 안됩니다. 이를 해결하려면 `powermock`를 사용하면 되는 것 같지만 enum mocking에 대한 자료가 적어 어려움이 있네요.

서비스쪽 코드가 좀 더럽다고 생각이 드네요..
의견 부탁드립니다!

Close #82 
