### PR TITLE
feat: 다른 아기 프로필 조회 API를 구현한다. 

### DIFF
--- a/back/src/main/java/com/baba/back/oauth/controller/MemberController.java
+++ b/back/src/main/java/com/baba/back/oauth/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.baba.back.oauth.controller;
 
+import com.baba.back.oauth.dto.BabyProfileResponse;
 import com.baba.back.oauth.dto.CreateGroupRequest;
 import com.baba.back.oauth.dto.MemberResponse;
 import com.baba.back.oauth.dto.MemberSignUpRequest;
@@ -24,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -81,7 +83,7 @@ public class MemberController {
     @IntervalServerErrorResponse
     @PostMapping("/members/groups")
     public ResponseEntity<Void> createGroup(@RequestBody @Valid CreateGroupRequest request,
-                                              @Login String memberId) {
+                                            @Login String memberId) {
         memberService.createGroup(memberId, request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
@@ -94,5 +96,15 @@ public class MemberController {
     @GetMapping("/members/my-page")
     public ResponseEntity<MyProfileResponse> searchMyProfile(@Login String memberId) {
         return ResponseEntity.ok(memberService.searchMyGroups(memberId));
+    }
+
+    @Operation(summary = "다른 아기 프로필 조회 요청")
+    @OkResponse
+    @UnAuthorizedResponse
+    @NotFoundResponse
+    @IntervalServerErrorResponse
+    @GetMapping("/members/baby-page/{babyId}")
+    public ResponseEntity<BabyProfileResponse> searchBabyProfile(@Login String memberId, @PathVariable String babyId) {
+        return ResponseEntity.ok(memberService.searchBabyGroups(memberId, babyId));
     }
 }

--- a/back/src/main/java/com/baba/back/oauth/dto/BabyProfileResponse.java
+++ b/back/src/main/java/com/baba/back/oauth/dto/BabyProfileResponse.java
@@ -1,0 +1,4 @@
+package com.baba.back.oauth.dto;
+
+public record BabyProfileResponse(FamilyGroupResponse familyGroup, GroupResponse myGroup) {
+}

--- a/back/src/main/java/com/baba/back/oauth/dto/FamilyGroupResponse.java
+++ b/back/src/main/java/com/baba/back/oauth/dto/FamilyGroupResponse.java
@@ -1,0 +1,7 @@
+package com.baba.back.oauth.dto;
+
+import com.baba.back.baby.dto.BabyResponse;
+import java.util.List;
+
+public record FamilyGroupResponse(String groupName, List<BabyResponse> babies, List<GroupMemberResponse> members) {
+}

--- a/back/src/main/java/com/baba/back/oauth/dto/GroupMemberResponse.java
+++ b/back/src/main/java/com/baba/back/oauth/dto/GroupMemberResponse.java
@@ -1,0 +1,5 @@
+package com.baba.back.oauth.dto;
+
+public record GroupMemberResponse(String memberId, String name, String relationName, String iconName,
+                                  String iconColor) {
+}

--- a/back/src/main/java/com/baba/back/oauth/dto/GroupResponse.java
+++ b/back/src/main/java/com/baba/back/oauth/dto/GroupResponse.java
@@ -1,0 +1,6 @@
+package com.baba.back.oauth.dto;
+
+import java.util.List;
+
+public record GroupResponse(String groupName, List<GroupMemberResponse> members) {
+}

--- a/back/src/main/java/com/baba/back/oauth/dto/GroupResponseWithFamily.java
+++ b/back/src/main/java/com/baba/back/oauth/dto/GroupResponseWithFamily.java
@@ -1,0 +1,6 @@
+package com.baba.back.oauth.dto;
+
+import java.util.List;
+
+public record GroupResponseWithFamily(String groupName, boolean family, List<GroupMemberResponse> members) {
+}

--- a/back/src/main/java/com/baba/back/oauth/dto/MyGroupMemberResponse.java
+++ b/back/src/main/java/com/baba/back/oauth/dto/MyGroupMemberResponse.java
@@ -1,5 +1,0 @@
-package com.baba.back.oauth.dto;
-
-public record MyGroupMemberResponse(String memberId, String name, String relationName, String iconName,
-                                    String iconColor) {
-}

--- a/back/src/main/java/com/baba/back/oauth/dto/MyGroupResponse.java
+++ b/back/src/main/java/com/baba/back/oauth/dto/MyGroupResponse.java
@@ -1,6 +1,0 @@
-package com.baba.back.oauth.dto;
-
-import java.util.List;
-
-public record MyGroupResponse(String groupName, boolean family, List<MyGroupMemberResponse> members) {
-}

--- a/back/src/main/java/com/baba/back/oauth/dto/MyProfileResponse.java
+++ b/back/src/main/java/com/baba/back/oauth/dto/MyProfileResponse.java
@@ -2,5 +2,5 @@ package com.baba.back.oauth.dto;
 
 import java.util.List;
 
-public record MyProfileResponse(List<MyGroupResponse> groups) {
+public record MyProfileResponse(List<GroupResponseWithFamily> groups) {
 }

--- a/back/src/main/java/com/baba/back/oauth/service/MemberService.java
+++ b/back/src/main/java/com/baba/back/oauth/service/MemberService.java
@@ -6,18 +6,24 @@ import com.baba.back.baby.domain.IdConstructor;
 import com.baba.back.baby.domain.invitation.Invitation;
 import com.baba.back.baby.domain.invitation.InvitationCode;
 import com.baba.back.baby.domain.invitation.Invitations;
+import com.baba.back.baby.dto.BabyResponse;
+import com.baba.back.baby.exception.BabyNotFoundException;
+import com.baba.back.baby.exception.RelationGroupNotFoundException;
 import com.baba.back.baby.repository.BabyRepository;
 import com.baba.back.baby.repository.InvitationRepository;
 import com.baba.back.oauth.domain.Picker;
 import com.baba.back.oauth.domain.member.Color;
 import com.baba.back.oauth.domain.member.Member;
 import com.baba.back.oauth.domain.token.Token;
+import com.baba.back.oauth.dto.BabyProfileResponse;
 import com.baba.back.oauth.dto.CreateGroupRequest;
+import com.baba.back.oauth.dto.FamilyGroupResponse;
+import com.baba.back.oauth.dto.GroupMemberResponse;
+import com.baba.back.oauth.dto.GroupResponse;
+import com.baba.back.oauth.dto.GroupResponseWithFamily;
 import com.baba.back.oauth.dto.MemberResponse;
 import com.baba.back.oauth.dto.MemberSignUpRequest;
 import com.baba.back.oauth.dto.MemberSignUpResponse;
-import com.baba.back.oauth.dto.MyGroupMemberResponse;
-import com.baba.back.oauth.dto.MyGroupResponse;
 import com.baba.back.oauth.dto.MyProfileResponse;
 import com.baba.back.oauth.dto.SignUpWithBabyResponse;
 import com.baba.back.oauth.dto.SignUpWithCodeRequest;
@@ -130,7 +136,7 @@ public class MemberService {
     }
 
     public MemberResponse findMember(String memberId) {
-        final Member member = getMember(memberId);
+        final Member member = getFirstMember(memberId);
 
         return new MemberResponse(
                 memberId,
@@ -141,7 +147,7 @@ public class MemberService {
         );
     }
 
-    private Member getMember(String memberId) {
+    private Member getFirstMember(String memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(memberId + "에 해당하는 멤버가 존재하지 않습니다."));
     }
@@ -184,7 +190,7 @@ public class MemberService {
     }
 
     public void createGroup(String memberId, CreateGroupRequest request) {
-        final Member member = getMember(memberId);
+        final Member member = getFirstMember(memberId);
         final List<Baby> myBabies = getMyBabies(member);
         final List<RelationGroup> relationGroups = getRelationGroupsByBabies(myBabies);
 
@@ -214,10 +220,10 @@ public class MemberService {
 
     private void validateRelationGroup(List<RelationGroup> relationGroups, String relationGroupName) {
         relationGroups.forEach(relationGroup -> {
-                    if (relationGroup.hasEqualName(relationGroupName)) {
-                        throw new RelationGroupBadRequestException("이미 존재하는 그룹 이름입니다.");
-                    }
-                });
+            if (relationGroup.hasEqualName(relationGroupName)) {
+                throw new RelationGroupBadRequestException("이미 존재하는 그룹 이름입니다.");
+            }
+        });
     }
 
     private void saveRelationGroups(CreateGroupRequest request, List<Baby> myBabies) {
@@ -231,12 +237,12 @@ public class MemberService {
     }
 
     public MyProfileResponse searchMyGroups(String memberId) {
-        final Member member = getMember(memberId);
+        final Member member = getFirstMember(memberId);
         final Baby firstBaby = findFirstBaby(member);
 
         final List<RelationGroup> relationGroups = getRelationGroupsByBaby(firstBaby);
         final List<Relation> relations = getRelationsByRelationGroups(relationGroups);
-        final List<MyGroupResponse> groups = getMyGroups(relations);
+        final List<GroupResponseWithFamily> groups = getMyGroups(relations);
 
         return new MyProfileResponse(groups);
     }
@@ -257,7 +263,7 @@ public class MemberService {
         return relationRepository.findAllByRelationGroupIn(relationGroups);
     }
 
-    private List<MyGroupResponse> getMyGroups(List<Relation> relations) {
+    private List<GroupResponseWithFamily> getMyGroups(List<Relation> relations) {
         return relations.stream()
                 .collect(Collectors.groupingBy(Relation::getRelationGroup))
                 .entrySet()
@@ -266,22 +272,94 @@ public class MemberService {
                     final RelationGroup relationGroup = entry.getKey();
                     final List<Relation> relationsByGroup = entry.getValue();
 
-                    return new MyGroupResponse(relationGroup.getRelationGroupName(), relationGroup.isFamily(),
+                    return new GroupResponseWithFamily(relationGroup.getRelationGroupName(), relationGroup.isFamily(),
                             getGroupMembers(relationsByGroup));
                 })
                 .toList();
     }
 
-    private List<MyGroupMemberResponse> getGroupMembers(List<Relation> relations) {
+    private List<GroupMemberResponse> getGroupMembers(List<Relation> relations) {
         return relations.stream()
                 .map(relation -> {
                     final Member member = relation.getMember();
-                    return new MyGroupMemberResponse(
+                    return new GroupMemberResponse(
                             member.getId(),
                             member.getName(),
                             relation.getRelationName(),
                             member.getIconName(),
                             member.getIconColor());
                 }).toList();
+    }
+
+    public BabyProfileResponse searchBabyGroups(String memberId, String babyId) {
+        final Member member = getFirstMember(memberId);
+        final Baby baby = getBaby(babyId);
+
+        final RelationGroup memberRelationGroup = getMemberRelationGroup(member, baby);
+        final RelationGroup familyRelationGroup = getFamilyRelationGroup(baby);
+
+        final FamilyGroupResponse familyGroupResponse = getFamilyGroup(familyRelationGroup);
+
+        if (memberRelationGroup.isFamily()) {
+            return new BabyProfileResponse(familyGroupResponse, null);
+        }
+
+        final GroupResponse groupResponse = getGroupResponse(memberRelationGroup);
+
+        return new BabyProfileResponse(familyGroupResponse, groupResponse);
+    }
+
+    private Baby getBaby(String babyId) {
+        return babyRepository.findById(babyId)
+                .orElseThrow(() -> new BabyNotFoundException(babyId + "에 해당하는 아기가 존재하지 않습니다."));
+    }
+
+    private RelationGroup getMemberRelationGroup(Member member, Baby baby) {
+        return relationRepository.findByMemberAndBaby(member, baby)
+                .orElseThrow(() -> new RelationNotFoundException("멤버와 아기의 관계가 존재하지 않습니다."))
+                .getRelationGroup();
+    }
+
+    private RelationGroup getFamilyRelationGroup(Baby baby) {
+        return relationGroupRepository.findByBabyAndFamily(baby, true)
+                .orElseThrow(() -> new RelationGroupNotFoundException("아기의 가족 그룹이 존재하지 않습니다."));
+    }
+
+    private FamilyGroupResponse getFamilyGroup(RelationGroup relationGroup) {
+        final List<BabyResponse> babyResponses = getBabies(relationGroup);
+
+        final List<GroupMemberResponse> groupMembers = getGroupMembersByRelationGroup(relationGroup);
+
+        return new FamilyGroupResponse(relationGroup.getRelationGroupName(), babyResponses, groupMembers);
+    }
+
+    private List<GroupMemberResponse> getGroupMembersByRelationGroup(RelationGroup relationGroup) {
+        final List<Relation> relations = relationRepository.findAllByRelationGroup(relationGroup);
+        return getGroupMembers(relations);
+    }
+
+    private List<BabyResponse> getBabies(RelationGroup relationGroup) {
+        final Member familyMember = getFirstMember(relationGroup);
+        final List<Relation> relations = relationRepository.findAllByMember(familyMember);
+
+        return relations.stream()
+                .map(relation -> {
+                    final RelationGroup group = relation.getRelationGroup();
+
+                    return new BabyResponse(group.getBabyId(), group.getGroupColor(), group.getBabyName());
+                })
+                .toList();
+    }
+
+    private Member getFirstMember(RelationGroup relationGroup) {
+        return relationRepository.findFirstByRelationGroup(relationGroup)
+                .orElseThrow(() -> new RelationNotFoundException("아기와의 관계가 존재하지 않습니다."))
+                .getMember();
+    }
+
+    private GroupResponse getGroupResponse(RelationGroup relationGroup) {
+        final List<GroupMemberResponse> groupMembers = getGroupMembersByRelationGroup(relationGroup);
+
+        return new GroupResponse(relationGroup.getRelationGroupName(), groupMembers);
     }
 }

--- a/back/src/main/java/com/baba/back/relation/repository/RelationGroupRepository.java
+++ b/back/src/main/java/com/baba/back/relation/repository/RelationGroupRepository.java
@@ -10,6 +10,8 @@ public interface RelationGroupRepository extends JpaRepository<RelationGroup, Lo
 
     Optional<RelationGroup> findByBabyAndRelationGroupNameValue(Baby baby, String relationGroupName);
 
+    Optional<RelationGroup> findByBabyAndFamily(Baby baby, boolean family);
+
     List<RelationGroup> findAllByBaby(Baby baby);
 
     List<RelationGroup> findAllByBabyIn(List<Baby> babies);

--- a/back/src/main/java/com/baba/back/relation/repository/RelationRepository.java
+++ b/back/src/main/java/com/baba/back/relation/repository/RelationRepository.java
@@ -21,5 +21,9 @@ public interface RelationRepository extends JpaRepository<Relation, Long> {
 
     Optional<Relation> findFirstByMemberAndRelationGroupFamily(Member member, boolean isFamily);
 
+    Optional<Relation> findFirstByRelationGroup(RelationGroup relationGroup);
+
+    List<Relation> findAllByRelationGroup(RelationGroup relationGroup);
+
     List<Relation> findAllByRelationGroupIn(List<RelationGroup> relationGroups);
 }

--- a/back/src/test/java/com/baba/back/AcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/AcceptanceTest.java
@@ -3,10 +3,11 @@ package com.baba.back;
 import static com.baba.back.SimpleRestAssured.get;
 import static com.baba.back.SimpleRestAssured.post;
 import static com.baba.back.SimpleRestAssured.thenExtract;
-import static com.baba.back.fixture.RequestFixture.그룹_추가_요청_데이터;
+import static com.baba.back.fixture.RequestFixture.그룹_추가_요청_데이터1;
 import static com.baba.back.fixture.RequestFixture.멤버_가입_요청_데이터;
 import static com.baba.back.fixture.RequestFixture.소셜_토큰_요청_데이터;
 import static com.baba.back.fixture.RequestFixture.약관_동의_요청_데이터;
+import static com.baba.back.fixture.RequestFixture.초대코드_생성_요청_데이터1;
 import static com.baba.back.fixture.RequestFixture.초대코드_생성_요청_데이터2;
 
 import com.baba.back.baby.dto.CreateInviteCodeRequest;
@@ -70,7 +71,7 @@ public class AcceptanceTest {
 
     protected ExtractableResponse<Response> 그룹_추가_요청(String accessToken) {
         return post(MEMBER_BASE_PATH + "/groups", Map.of("Authorization", "Bearer " + accessToken),
-                그룹_추가_요청_데이터);
+                그룹_추가_요청_데이터1);
     }
 
     protected ExtractableResponse<Response> 초대장_조회_요청(String code) {
@@ -141,6 +142,10 @@ public class AcceptanceTest {
         return 초대_코드_생성_요청(accessToken, 초대코드_생성_요청_데이터2);
     }
 
+    protected ExtractableResponse<Response> 외가_초대_코드_생성_요청(String accessToken) {
+        return 초대_코드_생성_요청(accessToken, 초대코드_생성_요청_데이터1);
+    }
+
     private ExtractableResponse<Response> 초대_코드_생성_요청(String accessToken, CreateInviteCodeRequest request) {
         return post(BABY_BASE_PATH + "/invite-code", Map.of("Authorization", "Bearer " + accessToken), request);
     }
@@ -151,6 +156,10 @@ public class AcceptanceTest {
 
     protected ExtractableResponse<Response> 마이_그룹별_조회_요청(String accessToken) {
         return get(MEMBER_BASE_PATH + "/my-page", Map.of("Authorization", "Bearer " + accessToken));
+    }
+
+    protected ExtractableResponse<Response> 다른_아기_프로필_조회_요청(String accessToken, String babyId) {
+        return get(MEMBER_BASE_PATH + "/baby-page/" + babyId, Map.of("Authorization", "Bearer " + accessToken));
     }
 
     protected Long getContentId(ExtractableResponse<Response> response) {

--- a/back/src/test/java/com/baba/back/fixture/RequestFixture.java
+++ b/back/src/test/java/com/baba/back/fixture/RequestFixture.java
@@ -33,7 +33,8 @@ public class RequestFixture {
     public static final MemberSignUpRequest 멤버_가입_요청_데이터 = new MemberSignUpRequest(
             "박재희", "PROFILE_W_1", "엄마", List.of(아기_생성_요청_데이터_1, 아기_생성_요청_데이터_2)
     );
-    public static final CreateGroupRequest 그룹_추가_요청_데이터 = new CreateGroupRequest("친가", "FFAEBA");
+    public static final CreateGroupRequest 그룹_추가_요청_데이터1 = new CreateGroupRequest("외가", "FFAEBA");
+    public static final CreateGroupRequest 그룹_추가_요청_데이터2 = new CreateGroupRequest("친가", "FFAEBA");
     public static final SignUpWithCodeRequest 초대코드로_멤버_가입_요청_데이터 = new SignUpWithCodeRequest(
             "AAAAAA", "박재희", "PROFILE_W_1"
     );

--- a/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
@@ -18,7 +18,8 @@ import static com.baba.back.fixture.DomainFixture.아기1;
 import static com.baba.back.fixture.DomainFixture.아기2;
 import static com.baba.back.fixture.DomainFixture.초대10;
 import static com.baba.back.fixture.DomainFixture.초대20;
-import static com.baba.back.fixture.RequestFixture.그룹_추가_요청_데이터;
+import static com.baba.back.fixture.RequestFixture.그룹_추가_요청_데이터1;
+import static com.baba.back.fixture.RequestFixture.그룹_추가_요청_데이터2;
 import static com.baba.back.fixture.RequestFixture.멤버_가입_요청_데이터;
 import static com.baba.back.fixture.RequestFixture.초대코드로_멤버_가입_요청_데이터;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -299,7 +300,7 @@ class MemberServiceTest {
         given(memberRepository.findById(멤버1.getId())).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> memberService.createGroup(멤버1.getId(), 그룹_추가_요청_데이터))
+        assertThatThrownBy(() -> memberService.createGroup(멤버1.getId(), 그룹_추가_요청_데이터1))
                 .isInstanceOf(MemberNotFoundException.class);
     }
 
@@ -310,7 +311,7 @@ class MemberServiceTest {
         given(relationRepository.findAllByMember(멤버1)).willReturn(List.of(관계22));
 
         // when & then
-        assertThatThrownBy(() -> memberService.createGroup(멤버1.getId(), 그룹_추가_요청_데이터))
+        assertThatThrownBy(() -> memberService.createGroup(멤버1.getId(), 그룹_추가_요청_데이터1))
                 .isInstanceOf(RelationNotFoundException.class);
     }
 
@@ -338,7 +339,7 @@ class MemberServiceTest {
         given(relationGroupRepository.findAllByBabyIn(anyList())).willReturn(List.of(관계그룹10, 관계그룹11, 관계그룹20, 관계그룹21));
 
         // when
-        memberService.createGroup(memberId, 그룹_추가_요청_데이터);
+        memberService.createGroup(memberId, 그룹_추가_요청_데이터2);
 
         // when & then
         then(relationGroupRepository).should(times(2)).save(any(RelationGroup.class));


### PR DESCRIPTION
## 상세 내용
다른 아기 프로필 조회 API를 구현하였습니다.

그룹 멤버들을 조회하는 로직은 `마이 그룹별 조회 API` 로직과 같은데
아기들을 조회하는 로직이 너무 더럽네요...
아기 그룹이 있어야 할 것 같은 느낌이네요,,,,


Close #102 
