### PR TITLE
성장 앨범 좋아요 자세히 보기 API를 구현한다

### DIFF
--- a/back/src/main/java/com/baba/back/content/controller/ContentController.java
+++ b/back/src/main/java/com/baba/back/content/controller/ContentController.java
@@ -5,6 +5,7 @@ import com.baba.back.content.dto.ContentsResponse;
 import com.baba.back.content.dto.CreateCommentRequest;
 import com.baba.back.content.dto.CreateContentRequest;
 import com.baba.back.content.dto.LikeContentResponse;
+import com.baba.back.content.dto.LikesResponse;
 import com.baba.back.content.service.ContentService;
 import com.baba.back.oauth.support.Login;
 import com.baba.back.swagger.BadRequestResponse;
@@ -84,12 +85,23 @@ public class ContentController {
     @NotFoundResponse
     @IntervalServerErrorResponse
     @GetMapping("/baby/{babyId}/album/{contentId}/comments")
-    public ResponseEntity<CommentsResponse> getContent(@Login String memberId,
+    public ResponseEntity<CommentsResponse> getComments(@Login String memberId,
                                                        @PathVariable("babyId") String babyId,
                                                        @PathVariable("contentId") Long contentId) {
         return ResponseEntity.ok(contentService.getComments(memberId, babyId, contentId));
     }
 
+    @Operation(summary = "성장 앨범 좋아요 보기 조회 요청")
+    @OkResponse
+    @UnAuthorizedResponse
+    @NotFoundResponse
+    @IntervalServerErrorResponse
+    @GetMapping("/baby/{babyId}/album/{contentId}/likes")
+    public ResponseEntity<LikesResponse> getlikes(@Login String memberId,
+                                                  @PathVariable("babyId") String babyId,
+                                                  @PathVariable("contentId") Long contentId) {
+        return ResponseEntity.ok(contentService.getLikes(memberId, babyId, contentId));
+    }
 
     @Operation(summary = "성장 앨범 댓글 추가 요청")
     @CreatedResponse

--- a/back/src/main/java/com/baba/back/content/dto/IconResponse.java
+++ b/back/src/main/java/com/baba/back/content/dto/IconResponse.java
@@ -1,0 +1,4 @@
+package com.baba.back.content.dto;
+
+public record IconResponse(String iconColor, String iconName) {
+}

--- a/back/src/main/java/com/baba/back/content/dto/LikesResponse.java
+++ b/back/src/main/java/com/baba/back/content/dto/LikesResponse.java
@@ -1,0 +1,7 @@
+package com.baba.back.content.dto;
+
+import com.baba.back.oauth.dto.MemberResponse;
+import java.util.List;
+
+public record LikesResponse(List<IconResponse> likeUsersPreview, List<MemberResponse> likeUsers) {
+}

--- a/back/src/main/java/com/baba/back/content/repository/LikeRepository.java
+++ b/back/src/main/java/com/baba/back/content/repository/LikeRepository.java
@@ -6,11 +6,13 @@ import com.baba.back.oauth.domain.member.Member;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
     Optional<Like> findByContentAndMember(Content content, Member member);
 
     boolean existsByContentAndMember(Content content, Member member);
 
+    @Query("select l from Like l where l.content = :content and l.deleted = false")
     List<Like> findAllByContent(Content content);
 }

--- a/back/src/test/java/com/baba/back/AcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/AcceptanceTest.java
@@ -156,6 +156,12 @@ public class AcceptanceTest {
                 Map.of("Authorization", "Bearer " + accessToken));
     }
 
+    protected ExtractableResponse<Response> 성장_앨범_좋아요_보기_요청(String accessToken, String babyId, Long contentId) {
+        return get(String.format("/%s/%s/%s/%s/%s/likes",
+                        BASE_PATH, BABY_BASE_PATH, babyId, CONTENT_BASE_PATH, contentId),
+                Map.of("Authorization", "Bearer " + accessToken));
+    }
+
     protected ExtractableResponse<Response> 마이_그룹별_조회_요청(String accessToken) {
         return get(String.format("/%s/%s/my-page", BASE_PATH, MEMBER_BASE_PATH),
                 Map.of("Authorization", "Bearer " + accessToken));

--- a/back/src/test/java/com/baba/back/content/acceptance/ContentAcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/content/acceptance/ContentAcceptanceTest.java
@@ -17,6 +17,7 @@ import com.baba.back.content.dto.ContentResponse;
 import com.baba.back.content.dto.ContentsResponse;
 import com.baba.back.content.dto.CreateCommentRequest;
 import com.baba.back.content.dto.LikeContentResponse;
+import com.baba.back.content.dto.LikesResponse;
 import com.baba.back.oauth.dto.MemberSignUpResponse;
 import com.baba.back.oauth.service.AccessTokenProvider;
 import io.restassured.RestAssured;
@@ -264,12 +265,38 @@ public class ContentAcceptanceTest extends AcceptanceTest {
         );
     }
 
+    @Test
+    void 성장_앨범의_모든_좋아요를_볼_수_있다() throws MalformedURLException {
+        // given
+        final ExtractableResponse<Response> signUpResponse1 = 아기_등록_회원가입_요청();
+        final String accessToken = toObject(signUpResponse1, MemberSignUpResponse.class).accessToken();
+        final String babyId = getBabyId(signUpResponse1);
+        given(amazonS3.getUrl(any(String.class), any(String.class))).willReturn(new URL(VALID_URL));
+        final Long contentId = getContentId(성장앨범_생성_요청(accessToken, babyId, nowDate));
+        좋아요_요청(accessToken, babyId, contentId);
+
+        // when
+        final ExtractableResponse<Response> httpResponse = 성장_앨범_좋아요_보기_요청(accessToken, babyId, contentId);
+
+        // then
+        final LikesResponse response = toObject(httpResponse, LikesResponse.class);
+        assertAll(
+                () -> assertThat(httpResponse.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.likeUsersPreview()).hasSize(1),
+                () -> assertThat(response.likeUsers()).hasSize(1)
+        );
+    }
+
     // TODO: 2023/03/26 멤버 초대 API 구현되면 테스트 작성
     @Test
-    void 성장_앨범_자세히_보기_요청_시_가족_멤버가_요청하면_모든_좋아요_댓글을_확인할_수_있다() {
+    void 성장_앨범_댓글_보기_요청_시_가족_멤버가_요청하면_모든_좋아요_댓글을_확인할_수_있다() {
     }
 
     @Test
-    void 성장_앨범_자세히_보기_요청_시_가족이_아닌_멤버가_요청하면_가족_및_소속_그룹의_좋아요_댓글만_확인할_수_있다() {
+    void 성장_앨범_댓글_보기_요청_시_가족이_아닌_멤버가_요청하면_가족_및_소속_그룹의_좋아요_댓글만_확인할_수_있다() {
+    }
+
+    @Test
+    void 성장_앨범_댓글_보기_요청_시_소속_그룹에_상관없이_모든_좋아요를_확인할_수_있다() {
     }
 }

--- a/back/src/test/java/com/baba/back/content/acceptance/ContentAcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/content/acceptance/ContentAcceptanceTest.java
@@ -191,11 +191,6 @@ public class ContentAcceptanceTest extends AcceptanceTest {
         );
     }
 
-    // TODO: 2023/03/12 초대 로직 생성 후 테스트 작성
-    @Test
-    void 원하는_년_월의_내가_올린_성장_앨범과_다른_사람이_올린_성장_앨범을_조회한다() {
-    }
-
     @Test
     void 태그를_하지않고_댓글을_추가할_수_있다() throws MalformedURLException {
         // given
@@ -214,11 +209,6 @@ public class ContentAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
                 () -> assertThat(getCommentId(response)).isPositive()
         );
-    }
-
-    // TODO: 2023/03/21 멤버 초대 API 구현 후 작성
-    @Test
-    void 태그를_하고_댓글을_추가할_수_있다() {
     }
 
     @Test
@@ -266,7 +256,7 @@ public class ContentAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 성장_앨범의_모든_좋아요를_볼_수_있다() throws MalformedURLException {
+    void 성장_앨범의_좋아요를_볼_수_있다() throws MalformedURLException {
         // given
         final ExtractableResponse<Response> signUpResponse1 = 아기_등록_회원가입_요청();
         final String accessToken = toObject(signUpResponse1, MemberSignUpResponse.class).accessToken();
@@ -287,7 +277,38 @@ public class ContentAcceptanceTest extends AcceptanceTest {
         );
     }
 
+    @Test
+    void 성장_앨범의_좋아요가_존재하지않으면_빈_리스트를_반환한다() throws MalformedURLException {
+        // given
+        final ExtractableResponse<Response> signUpResponse1 = 아기_등록_회원가입_요청();
+        final String accessToken = toObject(signUpResponse1, MemberSignUpResponse.class).accessToken();
+        final String babyId = getBabyId(signUpResponse1);
+        given(amazonS3.getUrl(any(String.class), any(String.class))).willReturn(new URL(VALID_URL));
+        final Long contentId = getContentId(성장앨범_생성_요청(accessToken, babyId, nowDate));
+        좋아요_요청(accessToken, babyId, contentId);
+        좋아요_요청(accessToken, babyId, contentId);
+
+        // when
+        final ExtractableResponse<Response> httpResponse = 성장_앨범_좋아요_보기_요청(accessToken, babyId, contentId);
+
+        // then
+        final LikesResponse response = toObject(httpResponse, LikesResponse.class);
+        assertAll(
+                () -> assertThat(httpResponse.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.likeUsersPreview()).hasSize(0),
+                () -> assertThat(response.likeUsers()).hasSize(0)
+        );
+    }
+
     // TODO: 2023/03/26 멤버 초대 API 구현되면 테스트 작성
+    @Test
+    void 원하는_년_월의_내가_올린_성장_앨범과_다른_사람이_올린_성장_앨범을_조회한다() {
+    }
+
+    @Test
+    void 태그를_하고_댓글을_추가할_수_있다() {
+    }
+
     @Test
     void 성장_앨범_댓글_보기_요청_시_가족_멤버가_요청하면_모든_좋아요_댓글을_확인할_수_있다() {
     }
@@ -297,6 +318,6 @@ public class ContentAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 성장_앨범_댓글_보기_요청_시_소속_그룹에_상관없이_모든_좋아요를_확인할_수_있다() {
+    void 성장_앨범_댓글_보기_요청_시_소속_그룹에_상관없이_모든_좋아요조를_확인할_수_있다() {
     }
 }

--- a/back/src/test/java/com/baba/back/content/acceptance/ContentAcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/content/acceptance/ContentAcceptanceTest.java
@@ -318,6 +318,6 @@ public class ContentAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 성장_앨범_댓글_보기_요청_시_소속_그룹에_상관없이_모든_좋아요조를_확인할_수_있다() {
+    void 성장_앨범_댓글_보기_요청_시_소속_그룹에_상관없이_모든_좋아요를_확인할_수_있다() {
     }
 }

--- a/back/src/test/java/com/baba/back/fixture/DomainFixture.java
+++ b/back/src/test/java/com/baba/back/fixture/DomainFixture.java
@@ -54,6 +54,13 @@ public class DomainFixture {
             .iconName(IconName.PROFILE_G_1.toString())
             .iconColor(Color.COLOR_1)
             .build();
+    public static final Member 멤버4 = Member.builder()
+            .id("member4")
+            .name("멤버4")
+            .introduction("안녕하세요")
+            .iconName(IconName.PROFILE_G_1.toString())
+            .iconColor(Color.COLOR_1)
+            .build();;
     public static final Token 토큰1 = Token.builder()
             .member(멤버1)
             .value("토큰1")
@@ -89,6 +96,22 @@ public class DomainFixture {
             .member(멤버1)
             .content(컨텐츠10)
             .build();
+
+    public static final Like 좋아요11 = Like.builder()
+            .member(멤버2)
+            .content(컨텐츠10)
+            .build();
+
+    public static final Like 좋아요12 = Like.builder()
+            .member(멤버3)
+            .content(컨텐츠10)
+            .build();
+
+    public static final Like 좋아요13 = Like.builder()
+            .member(멤버4)
+            .content(컨텐츠10)
+            .build();
+
     public static final Comment 댓글10 = Comment.builder()
             .owner(멤버1)
             .content(컨텐츠10)


### PR DESCRIPTION
## 상세 내용
성장 앨범 좋아요 자세히 보기 API를 구현하였습니다.
그룹에 상관없이 모든 좋아요를 조회할 수 있기 때문에 로직이 비교적 쉬웠습니다.

필요한 테스트만 작성하였습니다. 
의미 없는 테스트 작성은 그만해야될거같아서요..

테스트 진행중 soft delete를 하는 로직이 존재하면 delete 여부를 반영해야한다는 것을 깨달았습니다.
혹시라도 다른 API 에서 soft delete 를 사용한다면 delete 여부를 반영해야될 것 같습니다.

Close #105 