### PR TITLE
아이콘 색상 응답 시 RGB 형태로 응답하도록 변경

### DIFF
--- a/back/src/main/java/com/baba/back/oauth/domain/member/Color.java
+++ b/back/src/main/java/com/baba/back/oauth/domain/member/Color.java
@@ -10,8 +10,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum Color {
-    COLOR_1("FFAEBA"), COLOR_2("FF8698"), COLOR_3("FFE3C8"), COLOR_4("FFD2A7"), COLOR_5("FFD400"), COLOR_6("9ED883"),
-    COLOR_7("30BE9B"), COLOR_8("81E0D5"), COLOR_9("5BD2FF"), COLOR_10("97BEFF"), COLOR_11("98A2FF"), COLOR_12("BFA1FF");
+    COLOR_1("#FFAEBA"), COLOR_2("#FF8698"), COLOR_3("#FFE3C8"), COLOR_4("#FFD2A7"), COLOR_5("#FFD400"), COLOR_6("#9ED883"),
+    COLOR_7("#30BE9B"), COLOR_8("#81E0D5"), COLOR_9("#5BD2FF"), COLOR_10("#97BEFF"), COLOR_11("#98A2FF"), COLOR_12("#BFA1FF");
 
     private final String value;
 

--- a/back/src/main/java/com/baba/back/oauth/domain/member/Icon.java
+++ b/back/src/main/java/com/baba/back/oauth/domain/member/Icon.java
@@ -25,7 +25,7 @@ public class Icon {
     }
 
     public String getIconColor() {
-        return this.iconColor.name();
+        return this.iconColor.getValue();
     }
 
     public String getIconName() {

--- a/back/src/test/java/com/baba/back/fixture/RequestFixture.java
+++ b/back/src/test/java/com/baba/back/fixture/RequestFixture.java
@@ -33,8 +33,8 @@ public class RequestFixture {
     public static final MemberSignUpRequest 멤버_가입_요청_데이터 = new MemberSignUpRequest(
             "박재희", "PROFILE_W_1", "엄마", List.of(아기_생성_요청_데이터_1, 아기_생성_요청_데이터_2)
     );
-    public static final CreateGroupRequest 그룹_추가_요청_데이터1 = new CreateGroupRequest("외가", "FFAEBA");
-    public static final CreateGroupRequest 그룹_추가_요청_데이터2 = new CreateGroupRequest("친가", "FFAEBA");
+    public static final CreateGroupRequest 그룹_추가_요청_데이터1 = new CreateGroupRequest("외가", "#FFAEBA");
+    public static final CreateGroupRequest 그룹_추가_요청_데이터2 = new CreateGroupRequest("친가", "#FFAEBA");
     public static final SignUpWithCodeRequest 초대코드로_멤버_가입_요청_데이터 = new SignUpWithCodeRequest(
             "AAAAAA", "박재희", "PROFILE_W_1"
     );

--- a/back/src/test/java/com/baba/back/oauth/acceptance/MemberAcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/acceptance/MemberAcceptanceTest.java
@@ -118,7 +118,7 @@ class MemberAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(toObject(response, MemberResponse.class)).extracting("name", "introduction",
                                 "iconName", "iconColor")
-                        .containsExactly(멤버_가입_요청_데이터.getName(), "", 멤버_가입_요청_데이터.getIconName(), Color.COLOR_1.name())
+                        .containsExactly(멤버_가입_요청_데이터.getName(), "", 멤버_가입_요청_데이터.getIconName(), Color.COLOR_1.getValue())
         );
     }
 

--- a/back/src/test/java/com/baba/back/oauth/domain/member/ColorTest.java
+++ b/back/src/test/java/com/baba/back/oauth/domain/member/ColorTest.java
@@ -34,7 +34,7 @@ class ColorTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"FFAEBA", "FF8698", "FFE3C8"})
+    @ValueSource(strings = {"#FFAEBA", "#FF8698", "#FFE3C8"})
     void 유효한_아이콘_색을_선택한다(String color) {
         assertThatCode(() -> Color.from(color))
                 .doesNotThrowAnyException();

--- a/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
@@ -382,7 +382,7 @@ class MemberServiceTest {
         final MyProfileResponse response = memberService.searchMyGroups(memberId);
 
         // then
-        assertThat(response.groups()).containsExactly(
+        assertThat(response.groups()).contains(
                 new GroupResponseWithFamily(관계그룹10.getRelationGroupName(), 관계그룹10.isFamily(),
                         List.of(new GroupMemberResponse(
                                         멤버1.getId(),


### PR DESCRIPTION
## 상세 내용
아이콘 색상의 이름을 응답하던 것을 RGB 형태로 응답하도록 수정하였습니다.

정말 간단하긴한데,

# 하나 붙였다고 테스트 하나가 터졌습니다.
contains로 변경하니까 테스트가 통과했는데,
이유는 파악하지 못하겠네요..

Close #109 