### PR TITLE
feat: 마이 프로필 변경 API를 구현한다.

### DIFF
--- a/back/src/main/java/com/baba/back/oauth/controller/MemberController.java
+++ b/back/src/main/java/com/baba/back/oauth/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.baba.back.oauth.dto.CreateGroupRequest;
 import com.baba.back.oauth.dto.MemberResponse;
 import com.baba.back.oauth.dto.MemberSignUpRequest;
 import com.baba.back.oauth.dto.MemberSignUpResponse;
+import com.baba.back.oauth.dto.MemberUpdateRequest;
 import com.baba.back.oauth.dto.MyProfileResponse;
 import com.baba.back.oauth.dto.SignUpWithBabyResponse;
 import com.baba.back.oauth.dto.SignUpWithCodeRequest;
@@ -27,6 +28,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -59,6 +61,18 @@ public class MemberController {
     @GetMapping("/members")
     public ResponseEntity<MemberResponse> findMember(@Login String memberId) {
         return ResponseEntity.ok(memberService.findMember(memberId));
+    }
+
+    @Operation(summary = "마이 프로필 변경 요청")
+    @OkResponse
+    @UnAuthorizedResponse
+    @NotFoundResponse
+    @IntervalServerErrorResponse
+    @PutMapping("/members")
+    public ResponseEntity<Void> updateMember(@Login String memberId,
+                                             @RequestBody @Valid MemberUpdateRequest request) {
+        memberService.updateMember(memberId, request);
+        return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "초대코드로 멤버 생성 요청")

--- a/back/src/main/java/com/baba/back/oauth/domain/member/Member.java
+++ b/back/src/main/java/com/baba/back/oauth/domain/member/Member.java
@@ -34,6 +34,12 @@ public class Member extends BaseEntity {
         this.icon = Icon.of(iconColor, iconName);
     }
 
+    public void update(String name, String introduction, Color iconColor, String iconName) {
+        this.name = new Name(name);
+        this.introduction = new Introduction(introduction);
+        this.icon = Icon.of(iconColor, iconName);
+    }
+
     public String getName() {
         return this.name.getValue();
     }

--- a/back/src/main/java/com/baba/back/oauth/dto/MemberUpdateRequest.java
+++ b/back/src/main/java/com/baba/back/oauth/dto/MemberUpdateRequest.java
@@ -1,0 +1,24 @@
+package com.baba.back.oauth.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberUpdateRequest {
+
+    @NotNull
+    private String name;
+
+    @NotNull
+    private String introduction;
+
+    @NotNull
+    private String iconName;
+
+    @NotNull
+    private String iconColor;
+}

--- a/back/src/main/java/com/baba/back/oauth/service/MemberService.java
+++ b/back/src/main/java/com/baba/back/oauth/service/MemberService.java
@@ -24,6 +24,7 @@ import com.baba.back.oauth.dto.GroupResponseWithFamily;
 import com.baba.back.oauth.dto.MemberResponse;
 import com.baba.back.oauth.dto.MemberSignUpRequest;
 import com.baba.back.oauth.dto.MemberSignUpResponse;
+import com.baba.back.oauth.dto.MemberUpdateRequest;
 import com.baba.back.oauth.dto.MyProfileResponse;
 import com.baba.back.oauth.dto.SignUpWithBabyResponse;
 import com.baba.back.oauth.dto.SignUpWithCodeRequest;
@@ -150,6 +151,14 @@ public class MemberService {
     private Member getFirstMember(String memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(memberId + "에 해당하는 멤버가 존재하지 않습니다."));
+    }
+
+    public void updateMember(String memberId, MemberUpdateRequest request) {
+        final Member member = getFirstMember(memberId);
+        member.update(request.getName(), request.getIntroduction(), Color.from(request.getIconColor()),
+                request.getIconName());
+
+        memberRepository.save(member);
     }
 
     public SignUpWithBabyResponse signUpWithCode(SignUpWithCodeRequest request, String memberId) {

--- a/back/src/test/java/com/baba/back/AcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/AcceptanceTest.java
@@ -2,8 +2,10 @@ package com.baba.back;
 
 import static com.baba.back.SimpleRestAssured.get;
 import static com.baba.back.SimpleRestAssured.post;
+import static com.baba.back.SimpleRestAssured.put;
 import static com.baba.back.SimpleRestAssured.thenExtract;
 import static com.baba.back.fixture.RequestFixture.그룹_추가_요청_데이터1;
+import static com.baba.back.fixture.RequestFixture.마이_프로필_변경_요청_데이터;
 import static com.baba.back.fixture.RequestFixture.멤버_가입_요청_데이터;
 import static com.baba.back.fixture.RequestFixture.소셜_토큰_요청_데이터;
 import static com.baba.back.fixture.RequestFixture.약관_동의_요청_데이터;
@@ -81,6 +83,11 @@ public class AcceptanceTest {
     protected ExtractableResponse<Response> 사용자_정보_요청(String accessToken) {
         return get(String.format("/%s/%s", BASE_PATH, MEMBER_BASE_PATH),
                 Map.of("Authorization", "Bearer " + accessToken));
+    }
+
+    protected ExtractableResponse<Response> 마이_프로필_변경_요청(String accessToken) {
+        return put(String.format("/%s/%s", BASE_PATH, MEMBER_BASE_PATH),
+                Map.of("Authorization", "Bearer " + accessToken), 마이_프로필_변경_요청_데이터);
     }
 
     protected ExtractableResponse<Response> 소셜_로그인_요청() {

--- a/back/src/test/java/com/baba/back/SimpleRestAssured.java
+++ b/back/src/test/java/com/baba/back/SimpleRestAssured.java
@@ -4,7 +4,6 @@ import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
-import java.util.List;
 import java.util.Map;
 import org.springframework.http.MediaType;
 
@@ -35,6 +34,15 @@ public class SimpleRestAssured {
         return thenExtract(given.contentType(MediaType.APPLICATION_JSON_VALUE).when().post(path));
     }
 
+    public static ExtractableResponse<Response> put(String path, Map<String, String> headers, Object request) {
+        final RequestSpecification given = givenWithHeaders(headers);
+        if (request != null) {
+            given.body(request);
+        }
+
+        return thenExtract(given.contentType(MediaType.APPLICATION_JSON_VALUE).when().put(path));
+    }
+
     private static RequestSpecification givenWithHeaders(Map<String, String> headers) {
         final RequestSpecification given = given();
         if (headers != null) {
@@ -53,9 +61,5 @@ public class SimpleRestAssured {
 
     public static <T> T toObject(ExtractableResponse<Response> response, Class<T> clazz) {
         return response.as(clazz);
-    }
-
-    public static <T> List<T> toObjectList(ExtractableResponse<Response> response, Class<T> clazz) {
-        return response.body().jsonPath().getList(".", clazz);
     }
 }

--- a/back/src/test/java/com/baba/back/fixture/RequestFixture.java
+++ b/back/src/test/java/com/baba/back/fixture/RequestFixture.java
@@ -12,6 +12,7 @@ import com.baba.back.oauth.domain.Terms;
 import com.baba.back.oauth.dto.AgreeTermsRequest;
 import com.baba.back.oauth.dto.CreateGroupRequest;
 import com.baba.back.oauth.dto.MemberSignUpRequest;
+import com.baba.back.oauth.dto.MemberUpdateRequest;
 import com.baba.back.oauth.dto.SignUpWithCodeRequest;
 import com.baba.back.oauth.dto.SocialTokenRequest;
 import com.baba.back.oauth.dto.TermsRequest;
@@ -54,4 +55,8 @@ public class RequestFixture {
 
     public static final CreateInviteCodeRequest 초대코드_생성_요청_데이터2 = new CreateInviteCodeRequest(
             "가족", "아빠");
+
+    public static final MemberUpdateRequest 마이_프로필_변경_요청_데이터 = new MemberUpdateRequest(
+            "박재희2", "안녕하세요!", "PROFILE_W_2", "#81E0D5"
+    );
 }

--- a/back/src/test/java/com/baba/back/oauth/acceptance/MemberAcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/acceptance/MemberAcceptanceTest.java
@@ -2,6 +2,7 @@ package com.baba.back.oauth.acceptance;
 
 import static com.baba.back.SimpleRestAssured.post;
 import static com.baba.back.SimpleRestAssured.toObject;
+import static com.baba.back.fixture.RequestFixture.마이_프로필_변경_요청_데이터;
 import static com.baba.back.fixture.RequestFixture.멤버_가입_요청_데이터;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -118,7 +119,8 @@ class MemberAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(toObject(response, MemberResponse.class)).extracting("name", "introduction",
                                 "iconName", "iconColor")
-                        .containsExactly(멤버_가입_요청_데이터.getName(), "", 멤버_가입_요청_데이터.getIconName(), Color.COLOR_1.getValue())
+                        .containsExactly(멤버_가입_요청_데이터.getName(), "", 멤버_가입_요청_데이터.getIconName(),
+                                Color.COLOR_1.getValue())
         );
     }
 
@@ -132,6 +134,25 @@ class MemberAcceptanceTest extends AcceptanceTest {
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+    }
+
+    @Test
+    void 마이_프로필_변경_요청_시_멤버_정보를_변경한다() {
+        // given
+        final ExtractableResponse<Response> 아기_등록_회원가입_응답 = 아기_등록_회원가입_요청(멤버_가입_요청_데이터);
+        final String accessToken = toObject(아기_등록_회원가입_응답, MemberSignUpResponse.class).accessToken();
+
+        // when
+        final ExtractableResponse<Response> updateResponse = 마이_프로필_변경_요청(accessToken);
+
+        // then
+        final MemberResponse response = toObject(사용자_정보_요청(accessToken), MemberResponse.class);
+        assertAll(
+                () -> assertThat(updateResponse.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response).extracting("name", "introduction", "iconName", "iconColor")
+                        .containsExactly(마이_프로필_변경_요청_데이터.getName(), 마이_프로필_변경_요청_데이터.getIntroduction(), 마이_프로필_변경_요청_데이터.getIconName(),
+                                마이_프로필_변경_요청_데이터.getIconColor())
+        );
     }
 
     @Test

--- a/back/src/test/java/com/baba/back/oauth/domain/member/MemberTest.java
+++ b/back/src/test/java/com/baba/back/oauth/domain/member/MemberTest.java
@@ -1,0 +1,30 @@
+package com.baba.back.oauth.domain.member;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class MemberTest {
+
+    @Test
+    void update_메서드_호출_시_멤버의_정보를_변경한다() {
+        // given
+        final Member member = Member.builder()
+                .name("name")
+                .introduction("")
+                .iconColor(Color.from("#FFAEBA"))
+                .iconName("PROFILE_W_1")
+                .build();
+
+        final String newName = "name2";
+        final String newIntroduction = "newIntroduction";
+        final Color newColor = Color.from("#5BD2FF");
+        final String newIconName = "PROFILE_W_2";
+
+        // when
+        member.update(newName, newIntroduction, newColor, newIconName);
+
+        // then
+        Assertions.assertThat(member).extracting("name", "introduction", "iconColor", "iconName")
+                .containsExactly(newName, newIntroduction, newColor.getValue(), newIconName);
+    }
+}

--- a/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
@@ -20,6 +20,7 @@ import static com.baba.back.fixture.DomainFixture.초대10;
 import static com.baba.back.fixture.DomainFixture.초대20;
 import static com.baba.back.fixture.RequestFixture.그룹_추가_요청_데이터1;
 import static com.baba.back.fixture.RequestFixture.그룹_추가_요청_데이터2;
+import static com.baba.back.fixture.RequestFixture.마이_프로필_변경_요청_데이터;
 import static com.baba.back.fixture.RequestFixture.멤버_가입_요청_데이터;
 import static com.baba.back.fixture.RequestFixture.초대코드로_멤버_가입_요청_데이터;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -411,6 +412,22 @@ class MemberServiceTest {
                         )
                 )
         );
+    }
+
+    @Nested
+    class 마이_프로필_변경_시_ {
+        
+        @Test
+        void 멤버의_정보를_변경한다() {
+            // given
+            given(memberRepository.findById(멤버1.getId())).willReturn(Optional.of(멤버1));
+            
+            // when
+            memberService.updateMember(멤버1.getId(), 마이_프로필_변경_요청_데이터);
+            
+            // then
+            then(memberRepository).should().save(any(Member.class));
+        }
     }
 
     @Nested


### PR DESCRIPTION
## 상세 내용
마이 프로필 변경 API를 구현하였습니다.

HTTP Method를 `PATCH`가 아닌 `PUT`으로 설정한 이유는
해당 API가 멤버의 전체 리소스(이름, 소개, 아이콘)를 수정하기 때문입니다.

이후에 아기 이름을 변경하는 API의 경우 아기의 전체 리소스 중 이름만 수정하기 때문에 `PATCH`로 설정할 예정입니다.

Close #111 
