### PR TITLE
feat: 아기 이름 변경 API를 구현한다.

### DIFF
--- a/back/src/main/java/com/baba/back/baby/controller/BabyController.java
+++ b/back/src/main/java/com/baba/back/baby/controller/BabyController.java
@@ -1,6 +1,7 @@
 package com.baba.back.baby.controller;
 
 import com.baba.back.baby.dto.BabiesResponse;
+import com.baba.back.baby.dto.BabyNameRequest;
 import com.baba.back.baby.dto.CreateInviteCodeRequest;
 import com.baba.back.baby.dto.CreateInviteCodeResponse;
 import com.baba.back.baby.dto.SearchInviteCodeResponse;
@@ -19,6 +20,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -37,8 +40,21 @@ public class BabyController {
     @NotFoundResponse
     @IntervalServerErrorResponse
     @GetMapping("/baby")
-    public BabiesResponse findBabies(@Login String memberId) {
-        return babyService.findBabies(memberId);
+    public ResponseEntity<BabiesResponse> findBabies(@Login String memberId) {
+        return ResponseEntity.ok().body(babyService.findBabies(memberId));
+    }
+
+    @Operation(summary = "아기 이름 변경 요청")
+    @OkResponse
+    @UnAuthorizedResponse
+    @NotFoundResponse
+    @IntervalServerErrorResponse
+    @PatchMapping("/baby/{babyId}")
+    public ResponseEntity<Void> updateBabyName(@Login String memberId,
+                                               @PathVariable String babyId,
+                                               @RequestBody @NotNull BabyNameRequest request) {
+        babyService.updateBabyName(memberId, babyId, request.getName());
+        return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "초대 코드 생성 요청")

--- a/back/src/main/java/com/baba/back/baby/domain/Baby.java
+++ b/back/src/main/java/com/baba/back/baby/domain/Baby.java
@@ -40,4 +40,8 @@ public class Baby extends BaseEntity {
     public String getName() {
         return this.name.getValue();
     }
+
+    public void updateName(String name) {
+        this.name = new Name(name);
+    }
 }

--- a/back/src/main/java/com/baba/back/baby/dto/BabyNameRequest.java
+++ b/back/src/main/java/com/baba/back/baby/dto/BabyNameRequest.java
@@ -1,0 +1,15 @@
+package com.baba.back.baby.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class BabyNameRequest {
+
+    @NotNull
+    private String name;
+}

--- a/back/src/main/java/com/baba/back/oauth/exception/MemberAuthorizationException.java
+++ b/back/src/main/java/com/baba/back/oauth/exception/MemberAuthorizationException.java
@@ -1,0 +1,9 @@
+package com.baba.back.oauth.exception;
+
+import com.baba.back.exception.AuthorizationException;
+
+public class MemberAuthorizationException extends AuthorizationException {
+    public MemberAuthorizationException(String message) {
+        super(message);
+    }
+}

--- a/back/src/test/java/com/baba/back/AcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/AcceptanceTest.java
@@ -1,6 +1,7 @@
 package com.baba.back;
 
 import static com.baba.back.SimpleRestAssured.get;
+import static com.baba.back.SimpleRestAssured.patch;
 import static com.baba.back.SimpleRestAssured.post;
 import static com.baba.back.SimpleRestAssured.put;
 import static com.baba.back.SimpleRestAssured.thenExtract;
@@ -8,6 +9,8 @@ import static com.baba.back.fixture.RequestFixture.그룹_추가_요청_데이�
 import static com.baba.back.fixture.RequestFixture.마이_프로필_변경_요청_데이터;
 import static com.baba.back.fixture.RequestFixture.멤버_가입_요청_데이터;
 import static com.baba.back.fixture.RequestFixture.소셜_토큰_요청_데이터;
+import static com.baba.back.fixture.RequestFixture.아기_생성_요청_데이터_1;
+import static com.baba.back.fixture.RequestFixture.아기_이름_변경_요청_데이터;
 import static com.baba.back.fixture.RequestFixture.약관_동의_요청_데이터;
 import static com.baba.back.fixture.RequestFixture.초대코드_생성_요청_데이터1;
 import static com.baba.back.fixture.RequestFixture.초대코드_생성_요청_데이터2;
@@ -109,6 +112,11 @@ public class AcceptanceTest {
     protected ExtractableResponse<Response> 아기_리스트_조회_요청(String accessToken) {
         return get(String.format("/%s/%s", BASE_PATH, BABY_BASE_PATH),
                 Map.of("Authorization", "Bearer " + accessToken));
+    }
+
+    protected ExtractableResponse<Response> 아기_이름_변경_요청(String accessToken, String babyId) {
+        return patch(String.format("/%s/%s/%s", BASE_PATH, BABY_BASE_PATH, babyId),
+                Map.of("Authorization", "Bearer " + accessToken), 아기_이름_변경_요청_데이터);
     }
 
     protected ExtractableResponse<Response> 성장앨범_생성_요청(String accessToken, String babyId, LocalDate now) {

--- a/back/src/test/java/com/baba/back/SimpleRestAssured.java
+++ b/back/src/test/java/com/baba/back/SimpleRestAssured.java
@@ -43,6 +43,15 @@ public class SimpleRestAssured {
         return thenExtract(given.contentType(MediaType.APPLICATION_JSON_VALUE).when().put(path));
     }
 
+    public static ExtractableResponse<Response> patch(String path, Map<String, String> headers, Object request) {
+        final RequestSpecification given = givenWithHeaders(headers);
+        if (request != null) {
+            given.body(request);
+        }
+
+        return thenExtract(given.contentType(MediaType.APPLICATION_JSON_VALUE).when().patch(path));
+    }
+
     private static RequestSpecification givenWithHeaders(Map<String, String> headers) {
         final RequestSpecification given = given();
         if (headers != null) {

--- a/back/src/test/java/com/baba/back/baby/acceptance/BabyAcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/baby/acceptance/BabyAcceptanceTest.java
@@ -52,6 +52,20 @@ class BabyAcceptanceTest extends AcceptanceTest {
                         )
         );
     }
+    
+    @Test
+    void 아기_이름_변경_요청_시_아기_이름이_변경된다() {
+        // given
+        final ExtractableResponse<Response> 아기_등록_회원가입_응답 = 아기_등록_회원가입_요청();
+        final String accessToken = toObject(아기_등록_회원가입_응답, MemberSignUpResponse.class).accessToken();
+        final String babyId = getBabyId(아기_등록_회원가입_응답);
+
+        // when
+        final ExtractableResponse<Response> response = 아기_이름_변경_요청(accessToken, babyId);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
 
     @Test
     void 초대_코드_생성_요청_시_초대_코드를_생성한다() {

--- a/back/src/test/java/com/baba/back/baby/domain/BabyTest.java
+++ b/back/src/test/java/com/baba/back/baby/domain/BabyTest.java
@@ -1,0 +1,27 @@
+package com.baba.back.baby.domain;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+
+class BabyTest {
+
+    @Test
+    void updateName_메서드_호출_시_아기_이름을_변경한다() {
+        // given
+        final String babyName = "name";
+        final Baby baby = Baby.builder()
+                .name(babyName)
+                .birthday(LocalDate.now())
+                .now(LocalDate.now())
+                .build();
+
+        // when
+        final String newBabyName = "name2";
+        baby.updateName(newBabyName);
+
+        // then
+        assertEquals(newBabyName, baby.getName());
+    }
+}

--- a/back/src/test/java/com/baba/back/baby/service/BabyServiceTest.java
+++ b/back/src/test/java/com/baba/back/baby/service/BabyServiceTest.java
@@ -1,6 +1,7 @@
 package com.baba.back.baby.service;
 
 import static com.baba.back.fixture.DomainFixture.관계10;
+import static com.baba.back.fixture.DomainFixture.관계12;
 import static com.baba.back.fixture.DomainFixture.관계20;
 import static com.baba.back.fixture.DomainFixture.관계30;
 import static com.baba.back.fixture.DomainFixture.관계40;
@@ -27,6 +28,8 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
 
 import com.baba.back.baby.domain.Baby;
 import com.baba.back.baby.domain.invitation.Code;
@@ -37,10 +40,14 @@ import com.baba.back.baby.dto.BabyResponse;
 import com.baba.back.baby.dto.CreateInviteCodeResponse;
 import com.baba.back.baby.dto.InviteCodeBabyResponse;
 import com.baba.back.baby.dto.SearchInviteCodeResponse;
+import com.baba.back.baby.exception.BabyNotFoundException;
 import com.baba.back.baby.exception.InvitationCodeBadRequestException;
 import com.baba.back.baby.exception.InvitationsBadRequestException;
 import com.baba.back.baby.exception.RelationGroupNotFoundException;
+import com.baba.back.baby.repository.BabyRepository;
 import com.baba.back.baby.repository.InvitationRepository;
+import com.baba.back.oauth.domain.member.Member;
+import com.baba.back.oauth.exception.MemberAuthorizationException;
 import com.baba.back.oauth.exception.MemberNotFoundException;
 import com.baba.back.oauth.repository.MemberRepository;
 import com.baba.back.relation.domain.RelationGroup;
@@ -52,8 +59,10 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -66,6 +75,9 @@ class BabyServiceTest {
 
     @Mock
     private MemberRepository memberRepository;
+
+    @Mock
+    private BabyRepository babyRepository;
 
     @Mock
     private RelationRepository relationRepository;
@@ -113,6 +125,65 @@ class BabyServiceTest {
                         new BabyResponse(아기4.getId(), 관계그룹40.getGroupColor(), 아기4.getName())
                 )
         );
+    }
+
+    @Nested
+    class 아기_이름_변경_요청_시_ {
+        final String memberId = 멤버1.getId();
+        final String babyId = 아기1.getId();
+        final String babyName = "앙쥬";
+
+        @Test
+        void 아기가_없으면_예외를_던진다() {
+            // given
+            given(memberRepository.findById(memberId)).willReturn(Optional.of(멤버1));
+            given(babyRepository.findById(babyId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> babyService.updateBabyName(memberId, babyId, babyName))
+                    .isInstanceOf(BabyNotFoundException.class);
+        }
+
+        @Test
+        void 아기와의_관계가_없으면_예외를_던진다() {
+            // given
+            given(memberRepository.findById(memberId)).willReturn(Optional.of(멤버1));
+            given(babyRepository.findById(babyId)).willReturn(Optional.of(아기1));
+            given(relationRepository.findByMemberAndBaby(any(Member.class), any(Baby.class)))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> babyService.updateBabyName(memberId, babyId, babyName))
+                    .isInstanceOf(RelationNotFoundException.class);
+        }
+
+        @Test
+        void 아기와_가족_관계가_아니면_예외를_던진다() {
+            // given
+            given(memberRepository.findById(memberId)).willReturn(Optional.of(멤버1));
+            given(babyRepository.findById(babyId)).willReturn(Optional.of(아기1));
+            given(relationRepository.findByMemberAndBaby(any(Member.class), any(Baby.class)))
+                    .willReturn(Optional.of(관계12));
+
+            // when & then
+            assertThatThrownBy(() -> babyService.updateBabyName(memberId, babyId, babyName))
+                    .isInstanceOf(MemberAuthorizationException.class);
+        }
+
+        @Test
+        void 아기의_이름을_변경한다() {
+            // given
+            given(memberRepository.findById(memberId)).willReturn(Optional.of(멤버1));
+            given(babyRepository.findById(babyId)).willReturn(Optional.of(아기1));
+            given(relationRepository.findByMemberAndBaby(any(Member.class), any(Baby.class)))
+                    .willReturn(Optional.of(관계10));
+
+            // when
+            babyService.updateBabyName(memberId, babyId, babyName);
+
+            // then
+            then(babyRepository).should(times(1)).save(any(Baby.class));
+        }
     }
 
     @Test

--- a/back/src/test/java/com/baba/back/baby/service/BabyServiceTest.java
+++ b/back/src/test/java/com/baba/back/baby/service/BabyServiceTest.java
@@ -19,6 +19,7 @@ import static com.baba.back.fixture.DomainFixture.아기4;
 import static com.baba.back.fixture.DomainFixture.초대10;
 import static com.baba.back.fixture.DomainFixture.초대20;
 import static com.baba.back.fixture.DomainFixture.초대코드정보1;
+import static com.baba.back.fixture.RequestFixture.아기_이름_변경_요청_데이터;
 import static com.baba.back.fixture.RequestFixture.초대코드_생성_요청_데이터1;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -131,7 +132,7 @@ class BabyServiceTest {
     class 아기_이름_변경_요청_시_ {
         final String memberId = 멤버1.getId();
         final String babyId = 아기1.getId();
-        final String babyName = "앙쥬";
+        final String babyName = 아기_이름_변경_요청_데이터.getName();
 
         @Test
         void 아기가_없으면_예외를_던진다() {

--- a/back/src/test/java/com/baba/back/fixture/RequestFixture.java
+++ b/back/src/test/java/com/baba/back/fixture/RequestFixture.java
@@ -4,6 +4,7 @@ import static com.baba.back.content.domain.content.CardStyle.CARD_BASIC_1;
 import static com.baba.back.fixture.DomainFixture.멤버2;
 import static com.baba.back.fixture.DomainFixture.멤버3;
 
+import com.baba.back.baby.dto.BabyNameRequest;
 import com.baba.back.baby.dto.BabyRequest;
 import com.baba.back.baby.dto.CreateInviteCodeRequest;
 import com.baba.back.content.dto.CreateCommentRequest;
@@ -59,4 +60,6 @@ public class RequestFixture {
     public static final MemberUpdateRequest 마이_프로필_변경_요청_데이터 = new MemberUpdateRequest(
             "박재희2", "안녕하세요!", "PROFILE_W_2", "#81E0D5"
     );
+
+    public static final BabyNameRequest 아기_이름_변경_요청_데이터 = new BabyNameRequest("아기11");
 }


### PR DESCRIPTION
## 상세 내용
아기 이름 변경 API를 구현하였습니다.

멤버가 해당 아기와 가족 관계가 아니면 **멤버는 아기의 이름을 변경할 권한이 없는 것**이므로
`MemberAuthorizationException`을 던지도록 했습니다.

Close #117 
