### PR TITLE
fix: 가족 관계는 초대코드로 아기를 추가할 수 없게 한다.

### DIFF
--- a/back/src/main/java/com/baba/back/baby/service/BabyService.java
+++ b/back/src/main/java/com/baba/back/baby/service/BabyService.java
@@ -17,6 +17,7 @@ import com.baba.back.baby.dto.InviteCodeRequest;
 import com.baba.back.baby.dto.SearchInviteCodeResponse;
 import com.baba.back.baby.exception.BabyBadRequestException;
 import com.baba.back.baby.exception.BabyNotFoundException;
+import com.baba.back.baby.exception.InvitationCodeBadRequestException;
 import com.baba.back.baby.exception.RelationBadRequestException;
 import com.baba.back.baby.exception.RelationGroupNotFoundException;
 import com.baba.back.baby.repository.BabyRepository;
@@ -261,8 +262,19 @@ public class BabyService {
         final Invitations invitations = getInvitations(request.getInviteCode());
         final InvitationCode invitationCode = invitations.getUnExpiredInvitationCode(LocalDateTime.now(clock));
 
+        validateInvitationCode(invitations.values());
         validateRelations(invitations.values(), member);
         saveRelations(invitations.values(), invitationCode.getRelationName(), member);
+    }
+
+    private void validateInvitationCode(List<Invitation> invitations) {
+        invitations.forEach(invitation -> {
+            final RelationGroup relationGroup = invitation.getRelationGroup();
+
+            if (relationGroup.isFamily()) {
+                throw new InvitationCodeBadRequestException("가족 관계의 멤버는 회원가입으로만 등록할 수 있습니다.");
+            }
+        });
     }
 
     private Invitations getInvitations(String code) {

--- a/back/src/test/java/com/baba/back/AcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/AcceptanceTest.java
@@ -7,6 +7,7 @@ import static com.baba.back.SimpleRestAssured.post;
 import static com.baba.back.SimpleRestAssured.put;
 import static com.baba.back.SimpleRestAssured.thenExtract;
 import static com.baba.back.fixture.RequestFixture.그룹_추가_요청_데이터1;
+import static com.baba.back.fixture.RequestFixture.그룹_추가_요청_데이터2;
 import static com.baba.back.fixture.RequestFixture.마이_프로필_변경_요청_데이터;
 import static com.baba.back.fixture.RequestFixture.멤버_가입_요청_데이터;
 import static com.baba.back.fixture.RequestFixture.소셜_토큰_요청_데이터;
@@ -15,7 +16,6 @@ import static com.baba.back.fixture.RequestFixture.아기_추가_요청_데이�
 import static com.baba.back.fixture.RequestFixture.약관_동의_요청_데이터;
 import static com.baba.back.fixture.RequestFixture.초대코드_생성_요청_데이터1;
 import static com.baba.back.fixture.RequestFixture.초대코드_생성_요청_데이터2;
-import static com.baba.back.fixture.RequestFixture.초대코드로_아기_추가_요청_데이터;
 
 import com.baba.back.baby.dto.CreateInviteCodeRequest;
 import com.baba.back.baby.dto.InviteCodeRequest;
@@ -78,9 +78,14 @@ public class AcceptanceTest {
                 new SignUpWithCodeRequest(code, "박재희", "PROFILE_W_1"));
     }
 
-    protected ExtractableResponse<Response> 그룹_추가_요청(String accessToken) {
+    protected ExtractableResponse<Response> 외가_그룹_추가_요청(String accessToken) {
         return post(String.format("/%s/%s/groups", BASE_PATH, MEMBER_BASE_PATH),
                 Map.of("Authorization", "Bearer " + accessToken), 그룹_추가_요청_데이터1);
+    }
+
+    protected ExtractableResponse<Response> 가족_그룹_추가_요청(String accessToken) {
+        return post(String.format("/%s/%s/groups", BASE_PATH, MEMBER_BASE_PATH),
+                Map.of("Authorization", "Bearer " + accessToken), 그룹_추가_요청_데이터2);
     }
 
     protected ExtractableResponse<Response> 초대장_조회_요청(String code) {

--- a/back/src/test/java/com/baba/back/baby/acceptance/BabyAcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/baby/acceptance/BabyAcceptanceTest.java
@@ -37,7 +37,7 @@ class BabyAcceptanceTest extends AcceptanceTest {
         void 자신의_아기가_없다면_아기를_추가한다() {
             // given
             final String accessToken = toObject(아기_등록_회원가입_요청(), MemberSignUpResponse.class).accessToken();
-            그룹_추가_요청(accessToken);
+            외가_그룹_추가_요청(accessToken);
             final String inviteCode = toObject(외가_초대_코드_생성_요청(accessToken),
                     CreateInviteCodeResponse.class).inviteCode();
             final String token = toObject(초대코드로_회원가입_요청(memberId, inviteCode),
@@ -184,7 +184,7 @@ class BabyAcceptanceTest extends AcceptanceTest {
             final String accessToken = toObject(signUpResponse, MemberSignUpResponse.class).accessToken();
             final String babyId = getBabyId(signUpResponse);
 
-            그룹_추가_요청(accessToken);
+            외가_그룹_추가_요청(accessToken);
             final String inviteCode = toObject(외가_초대_코드_생성_요청(accessToken),
                     CreateInviteCodeResponse.class).inviteCode();
 
@@ -200,11 +200,30 @@ class BabyAcceptanceTest extends AcceptanceTest {
         }
 
         @Test
+        void 가족_관계의_멤버가_추가한다면_400를_던진다() {
+            // given
+            final ExtractableResponse<Response> signUpResponse = 아기_등록_회원가입_요청();
+            final String accessToken = toObject(signUpResponse, MemberSignUpResponse.class).accessToken();
+
+            가족_그룹_추가_요청(accessToken);
+            final String inviteCode = toObject(가족_초대_코드_생성_요청(accessToken),
+                    CreateInviteCodeResponse.class).inviteCode();
+
+            final String accessToken2 = toObject(아기_등록_회원가입_요청(), MemberSignUpResponse.class).accessToken();
+
+            // when
+            final ExtractableResponse<Response> response = 초대코드로_아기_추가_요청(accessToken2, inviteCode);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        }
+
+        @Test
         void 이미_관계가_존재하면_400을_던진다() {
             // given
             final String accessToken = toObject(아기_등록_회원가입_요청(), MemberSignUpResponse.class).accessToken();
 
-            그룹_추가_요청(accessToken);
+            외가_그룹_추가_요청(accessToken);
             final ExtractableResponse<Response> 외가_초대_코드_생성_응답 = 외가_초대_코드_생성_요청(accessToken);
             final String inviteCode = toObject(외가_초대_코드_생성_응답, CreateInviteCodeResponse.class).inviteCode();
 
@@ -218,6 +237,8 @@ class BabyAcceptanceTest extends AcceptanceTest {
             assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
         }
     }
+
+
 
     @TestConfiguration
     static class TestConfig {

--- a/back/src/test/java/com/baba/back/oauth/acceptance/MemberAcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/acceptance/MemberAcceptanceTest.java
@@ -204,7 +204,7 @@ class MemberAcceptanceTest extends AcceptanceTest {
         final String accessToken = toObject(아기_등록_회원가입_응답, MemberSignUpResponse.class).accessToken();
 
         // when
-        final ExtractableResponse<Response> response = 그룹_추가_요청(accessToken);
+        final ExtractableResponse<Response> response = 외가_그룹_추가_요청(accessToken);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
@@ -215,10 +215,10 @@ class MemberAcceptanceTest extends AcceptanceTest {
         // given
         final ExtractableResponse<Response> 아기_등록_회원가입_응답 = 아기_등록_회원가입_요청(멤버_가입_요청_데이터);
         final String accessToken = toObject(아기_등록_회원가입_응답, MemberSignUpResponse.class).accessToken();
-        그룹_추가_요청(accessToken);
+        외가_그룹_추가_요청(accessToken);
 
         // when
-        final ExtractableResponse<Response> response = 그룹_추가_요청(accessToken);
+        final ExtractableResponse<Response> response = 외가_그룹_추가_요청(accessToken);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
@@ -233,7 +233,7 @@ class MemberAcceptanceTest extends AcceptanceTest {
         final ExtractableResponse<Response> 아기_등록_회원가입_응답 = 아기_등록_회원가입_요청(memberId1);
         final String accessToken = toObject(아기_등록_회원가입_응답, MemberSignUpResponse.class).accessToken();
 
-        그룹_추가_요청(accessToken);
+        외가_그룹_추가_요청(accessToken);
 
         final ExtractableResponse<Response> 가족_초대_코드_생성_응답 = 외가_초대_코드_생성_요청(accessToken);
         final String code = toObject(가족_초대_코드_생성_응답, CreateInviteCodeResponse.class).inviteCode();
@@ -284,7 +284,7 @@ class MemberAcceptanceTest extends AcceptanceTest {
         final ExtractableResponse<Response> 아기_등록_회원가입_응답 = 아기_등록_회원가입_요청(memberId1);
         final String accessToken = toObject(아기_등록_회원가입_응답, MemberSignUpResponse.class).accessToken();
 
-        그룹_추가_요청(accessToken);
+        외가_그룹_추가_요청(accessToken);
 
         final ExtractableResponse<Response> 가족_초대_코드_생성_응답 = 외가_초대_코드_생성_요청(accessToken);
         final String code = toObject(가족_초대_코드_생성_응답, CreateInviteCodeResponse.class).inviteCode();
@@ -350,7 +350,7 @@ class MemberAcceptanceTest extends AcceptanceTest {
             final ExtractableResponse<Response> 아기_등록_회원가입_응답 = 아기_등록_회원가입_요청(memberId1);
             final String accessToken = toObject(아기_등록_회원가입_응답, MemberSignUpResponse.class).accessToken();
 
-            그룹_추가_요청(accessToken);
+            외가_그룹_추가_요청(accessToken);
 
             final ExtractableResponse<Response> 외가_초대_코드_생성_응답 = 외가_초대_코드_생성_요청(accessToken);
             final String code = toObject(외가_초대_코드_생성_응답, CreateInviteCodeResponse.class).inviteCode();


### PR DESCRIPTION
## 상세 내용
이전 미팅 때 논의했던 내용입니다.

가족 멤버는 회원가입만을 통해 등록될 수 있도록 변경하였습니다.

Close #132 
