### PR TITLE
refactor: 그룹 멤버 정보 변경 API에서 query parameter를 삭제한다.

### DIFF
--- a/back/src/main/java/com/baba/back/oauth/controller/MemberController.java
+++ b/back/src/main/java/com/baba/back/oauth/controller/MemberController.java
@@ -147,9 +147,8 @@ public class MemberController {
     @PatchMapping("/members/groups/{groupMemberId}")
     public ResponseEntity<Void> updateGroupMember(@Login String memberId,
                                                   @PathVariable String groupMemberId,
-                                                  @RequestParam("groupName") String groupName,
                                                   @RequestBody @Valid UpdateGroupMemberRequest request) {
-        memberService.updateGroupMember(memberId, groupMemberId, groupName, request);
+        memberService.updateGroupMember(memberId, groupMemberId, request);
         return ResponseEntity.ok().build();
     }
 }

--- a/back/src/main/java/com/baba/back/relation/domain/Relation.java
+++ b/back/src/main/java/com/baba/back/relation/domain/Relation.java
@@ -67,6 +67,10 @@ public class Relation extends BaseEntity {
         return this.relationGroup.equals(relationGroup);
     }
 
+    public boolean hasMember(Member member) {
+        return this.member.equals(member);
+    }
+
     public void updateRelationName(String relationName) {
         this.relationName = new Name(relationName);
     }

--- a/back/src/main/java/com/baba/back/relation/repository/RelationRepository.java
+++ b/back/src/main/java/com/baba/back/relation/repository/RelationRepository.java
@@ -26,6 +26,4 @@ public interface RelationRepository extends JpaRepository<Relation, Long> {
     List<Relation> findAllByRelationGroup(RelationGroup relationGroup);
 
     List<Relation> findAllByRelationGroupIn(List<RelationGroup> relationGroups);
-
-    Optional<Relation> findByMemberAndRelationGroup(Member member, RelationGroup relationGroup);
 }

--- a/back/src/test/java/com/baba/back/AcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/AcceptanceTest.java
@@ -99,7 +99,7 @@ public class AcceptanceTest {
     }
 
     protected ExtractableResponse<Response> 그룹_멤버_정보_변경_요청(String accessToken, String memberId) {
-        return patch(String.format("/%s/%s/groups/%s?groupName=%s", BASE_PATH, MEMBER_BASE_PATH, memberId, "외가"),
+        return patch(String.format("/%s/%s/groups/%s", BASE_PATH, MEMBER_BASE_PATH, memberId),
                 Map.of("Authorization", "Bearer " + accessToken), 그룹_멤버_정보_변경_요청_데이터);
     }
 

--- a/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
@@ -671,7 +671,6 @@ class MemberServiceTest {
 
         final String memberId = 멤버1.getId();
         final String groupMemberId = 멤버3.getId();
-        final String groupName = "외가";
 
         @Test
         void 요청받은_멤버가_그룹에_속하지_않는다면_예외를_던진다() {
@@ -681,12 +680,10 @@ class MemberServiceTest {
             given(relationRepository.findFirstByMemberAndRelationGroupFamily(any(Member.class), eq(true)))
                     .willReturn(Optional.of(관계10));
             given(relationGroupRepository.findAllByBaby(any(Baby.class))).willReturn(List.of(관계그룹10, 관계그룹11));
-            given(relationRepository.findByMemberAndRelationGroup(any(Member.class), any(RelationGroup.class)))
-                    .willReturn(Optional.empty());
+            given(relationRepository.findAllByRelationGroupIn(anyList())).willReturn(List.of(관계10, 관계11));
 
             // when & then
-            assertThatThrownBy(
-                    () -> memberService.updateGroupMember(memberId, groupMemberId, groupName, 그룹_멤버_정보_변경_요청_데이터))
+            assertThatThrownBy(() -> memberService.updateGroupMember(memberId, groupMemberId, 그룹_멤버_정보_변경_요청_데이터))
                     .isInstanceOf(RelationNotFoundException.class);
         }
 
@@ -704,11 +701,10 @@ class MemberServiceTest {
             given(relationRepository.findFirstByMemberAndRelationGroupFamily(any(Member.class), eq(true)))
                     .willReturn(Optional.of(관계10));
             given(relationGroupRepository.findAllByBaby(any(Baby.class))).willReturn(List.of(관계그룹10, 관계그룹11));
-            given(relationRepository.findByMemberAndRelationGroup(any(Member.class), any(RelationGroup.class)))
-                    .willReturn(Optional.of(relation));
+            given(relationRepository.findAllByRelationGroupIn(anyList())).willReturn(List.of(관계10, 관계11, relation));
 
             // when
-            memberService.updateGroupMember(memberId, groupMemberId, groupName, 그룹_멤버_정보_변경_요청_데이터);
+            memberService.updateGroupMember(memberId, groupMemberId, 그룹_멤버_정보_변경_요청_데이터);
 
             // then
             assertThat(relation.getRelationName()).isEqualTo(그룹_멤버_정보_변경_요청_데이터.getRelationName());


### PR DESCRIPTION
## 상세 내용
groupName query paramter를 사용하지 않도록 수정하였습니다.

Close #138 
