### PR TITLE
feat: 그룹 삭제 API를 구현한다.

### DIFF
--- a/back/src/main/java/com/baba/back/baby/domain/invitation/Invitation.java
+++ b/back/src/main/java/com/baba/back/baby/domain/invitation/Invitation.java
@@ -12,6 +12,8 @@ import jakarta.persistence.ManyToOne;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -26,6 +28,7 @@ public class Invitation extends BaseEntity {
     private InvitationCode invitationCode;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private RelationGroup relationGroup;
 
     @Builder

--- a/back/src/main/java/com/baba/back/content/controller/ContentController.java
+++ b/back/src/main/java/com/baba/back/content/controller/ContentController.java
@@ -92,7 +92,7 @@ public class ContentController {
     @IntervalServerErrorResponse
     @GetMapping("/baby/{babyId}/album/all")
     public ResponseEntity<ContentsResponse> getAllContents(@Login String memberId,
-                                                        @PathVariable("babyId") String babyId) {
+                                                           @PathVariable("babyId") String babyId) {
         return ResponseEntity.ok(contentService.getAllContents(memberId, babyId));
     }
 

--- a/back/src/main/java/com/baba/back/content/service/ContentService.java
+++ b/back/src/main/java/com/baba/back/content/service/ContentService.java
@@ -4,7 +4,6 @@ import com.baba.back.baby.domain.Baby;
 import com.baba.back.baby.exception.BabyNotFoundException;
 import com.baba.back.baby.repository.BabyRepository;
 import com.baba.back.common.FileHandler;
-import com.baba.back.common.Generated;
 import com.baba.back.content.domain.Like;
 import com.baba.back.content.domain.comment.Comment;
 import com.baba.back.content.domain.comment.Tag;

--- a/back/src/main/java/com/baba/back/oauth/controller/MemberController.java
+++ b/back/src/main/java/com/baba/back/oauth/controller/MemberController.java
@@ -163,4 +163,15 @@ public class MemberController {
         memberService.deleteGroupMember(memberId, groupMemberId);
         return ResponseEntity.ok().build();
     }
+
+    @Operation(summary = "그룹 삭제 요청")
+    @OkResponse
+    @UnAuthorizedResponse
+    @NotFoundResponse
+    @IntervalServerErrorResponse
+    @DeleteMapping("/members/groups")
+    public ResponseEntity<Void> deleteGroup(@Login String memberId, @RequestParam("groupName") String groupName) {
+        memberService.deleteGroup(memberId, groupName);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/back/src/main/java/com/baba/back/oauth/service/MemberService.java
+++ b/back/src/main/java/com/baba/back/oauth/service/MemberService.java
@@ -408,20 +408,6 @@ public class MemberService {
         updateRelationNames(relations, request.getRelationName());
     }
 
-    private List<Relation> getRelationsByMember(List<RelationGroup> relationsGroups, Member groupMember) {
-        final List<Relation> relations = getRelationsByRelationGroups(relationsGroups);
-
-        final List<Relation> relationsByMember = relations.stream()
-                .filter(relation -> relation.hasMember(groupMember))
-                .toList();
-
-        if (relationsByMember.isEmpty()) {
-            throw new RelationNotFoundException("{" + groupMember.getId() + "}는 그룹의 멤버가 아닙니다.");
-        }
-
-        return relationsByMember;
-    }
-
     private void updateRelationNames(List<Relation> relations, String relationName) {
         relations.forEach(relation -> relation.updateRelationName(relationName));
     }
@@ -440,5 +426,36 @@ public class MemberService {
         final List<RelationGroup> relationGroups = getRelationGroupsByBaby(firstBaby);
 
         return getRelationsByMember(relationGroups, groupMember);
+    }
+
+    private List<Relation> getRelationsByMember(List<RelationGroup> relationsGroups, Member groupMember) {
+        final List<Relation> relations = getRelationsByRelationGroups(relationsGroups);
+
+        final List<Relation> relationsByMember = relations.stream()
+                .filter(relation -> relation.hasMember(groupMember))
+                .toList();
+
+        if (relationsByMember.isEmpty()) {
+            throw new RelationNotFoundException("{" + groupMember.getId() + "}는 그룹의 멤버가 아닙니다.");
+        }
+
+        return relationsByMember;
+    }
+
+    public void deleteGroup(String memberId, String groupName) {
+        final List<RelationGroup> relationGroups = getMyRelationGroupsByGroup(memberId, groupName);
+
+        relationGroupRepository.deleteAllInBatch(relationGroups);
+    }
+
+    private List<RelationGroup> getMyRelationGroupsByGroup(String memberId, String groupName) {
+        final Member member = getFirstMember(memberId);
+        final Baby firstBaby = findFirstBaby(member);
+
+        final List<RelationGroup> relationGroups = getRelationGroupsByBaby(firstBaby);
+
+        return relationGroups.stream()
+                .filter(relationGroup -> relationGroup.hasEqualGroupName(groupName))
+                .toList();
     }
 }

--- a/back/src/main/java/com/baba/back/relation/domain/Relation.java
+++ b/back/src/main/java/com/baba/back/relation/domain/Relation.java
@@ -16,6 +16,8 @@ import jakarta.persistence.ManyToOne;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -34,6 +36,7 @@ public class Relation extends BaseEntity {
     private Name relationName;
 
     @ManyToOne(fetch = FetchType.EAGER)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private RelationGroup relationGroup;
 
     @Builder

--- a/back/src/test/java/com/baba/back/AcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/AcceptanceTest.java
@@ -103,6 +103,11 @@ public class AcceptanceTest {
                 Map.of("Authorization", "Bearer " + accessToken), 그룹_멤버_정보_변경_요청_데이터);
     }
 
+    protected ExtractableResponse<Response> 외가_그룹_삭제_요청(String accessToken) {
+        return delete(String.format("/%s/%s/groups?groupName=%s", BASE_PATH, MEMBER_BASE_PATH, "외가"),
+                Map.of("Authorization", "Bearer " + accessToken));
+    }
+
     protected ExtractableResponse<Response> 그룹_멤버_삭제_요청(String accessToken, String memberId) {
         return delete(String.format("/%s/%s/groups/%s", BASE_PATH, MEMBER_BASE_PATH, memberId),
                 Map.of("Authorization", "Bearer " + accessToken));

--- a/back/src/test/java/com/baba/back/oauth/acceptance/MemberAcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/acceptance/MemberAcceptanceTest.java
@@ -391,6 +391,36 @@ class MemberAcceptanceTest extends AcceptanceTest {
         assertThat(notFamilyGroup2.members()).isEmpty();
     }
 
+    @Test
+    void 그룹_삭제_시_그룹_및_아기와_그룹_멤버간의_관계가_삭제된다() {
+        // given
+        final String memberId = "memberId";
+
+        final ExtractableResponse<Response> 아기_등록_회원가입_응답 = 아기_등록_회원가입_요청(멤버_가입_요청_데이터);
+        final String accessToken = toObject(아기_등록_회원가입_응답, MemberSignUpResponse.class).accessToken();
+        외가_그룹_추가_요청(accessToken);
+
+        final ExtractableResponse<Response> 외가_초대_코드_생성_응답 = 외가_초대_코드_생성_요청(accessToken);
+        final String code = toObject(외가_초대_코드_생성_응답, CreateInviteCodeResponse.class).inviteCode();
+
+        초대코드로_회원가입_요청(memberId, code);
+
+        final ExtractableResponse<Response> 마이_그룹별_조회_응답 = 마이_그룹별_조회_요청(accessToken);
+        final List<GroupResponseWithFamily> groups = toObject(마이_그룹별_조회_응답, MyProfileResponse.class).groups();
+
+        assertThat(groups).hasSize(2);
+
+        // when
+        final ExtractableResponse<Response> response = 외가_그룹_삭제_요청(accessToken);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+
+        // then
+        final ExtractableResponse<Response> 마이_그룹별_조회_응답2 = 마이_그룹별_조회_요청(accessToken);
+        final List<GroupResponseWithFamily> groups2 = toObject(마이_그룹별_조회_응답2, MyProfileResponse.class).groups();
+
+        assertThat(groups2).hasSize(1);
+    }
+
     @TestConfiguration
     static class TestConfig {
         @Bean

--- a/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
@@ -740,4 +740,33 @@ class MemberServiceTest {
             then(relationRepository).should(times(1)).deleteAllInBatch(List.of(relation));
         }
     }
+
+    @Nested
+    class 그룹_삭제_시_ {
+
+        final String memberId = 멤버1.getId();
+        final String groupName = "외가";
+
+        @Test
+        void 그룹을_삭제한다() {
+            // given
+            final RelationGroup relationGroup = RelationGroup.builder()
+                    .baby(아기1)
+                    .relationGroupName(groupName)
+                    .family(false)
+                    .groupColor(Color.COLOR_1)
+                    .build();
+
+            given(memberRepository.findById(memberId)).willReturn(Optional.of(멤버1));
+            given(relationRepository.findFirstByMemberAndRelationGroupFamily(any(Member.class), eq(true)))
+                    .willReturn(Optional.of(관계10));
+            given(relationGroupRepository.findAllByBaby(any(Baby.class))).willReturn(List.of(관계그룹10, relationGroup));
+
+            // when
+            memberService.deleteGroup(memberId, groupName);
+
+            // then
+            then(relationGroupRepository).should(times(1)).deleteAllInBatch(List.of(relationGroup));
+        }
+    }
 }


### PR DESCRIPTION
## 상세 내용
그룹 삭제 API를 구현하였습니다.

그룹이 삭제되면 연관된 `관계` 및 `초대코드`까지 함께 삭제되도록 하였습니다.


<img width="326" alt="스크린샷 2023-05-07 13 40 49" src="https://user-images.githubusercontent.com/56298375/236658036-9002f52c-e549-4b00-861b-df80c0af8e1a.png">

<img width="325" alt="스크린샷 2023-05-07 13 40 41" src="https://user-images.githubusercontent.com/56298375/236658047-1911090b-850c-4bcb-be11-bb6e96cb5d69.png">

Close #143 
