### PR TITLE
feat: 성장 앨범 한개 조회 API 구현

### DIFF
--- a/back/src/main/java/com/baba/back/content/controller/ContentController.java
+++ b/back/src/main/java/com/baba/back/content/controller/ContentController.java
@@ -1,6 +1,7 @@
 package com.baba.back.content.controller;
 
 import com.baba.back.content.dto.CommentsResponse;
+import com.baba.back.content.dto.ContentResponse;
 import com.baba.back.content.dto.ContentUpdateTitleAndCardStyleRequest;
 import com.baba.back.content.dto.ContentsResponse;
 import com.baba.back.content.dto.CreateCommentRequest;
@@ -94,6 +95,18 @@ public class ContentController {
     public ResponseEntity<ContentsResponse> getAllContents(@Login String memberId,
                                                            @PathVariable("babyId") String babyId) {
         return ResponseEntity.ok(contentService.getAllContents(memberId, babyId));
+    }
+
+    @Operation(summary = "성장 앨범 한개 조회 요청")
+    @OkResponse
+    @UnAuthorizedResponse
+    @NotFoundResponse
+    @IntervalServerErrorResponse
+    @GetMapping("/baby/{babyId}/album/{contentId}")
+    public ResponseEntity<ContentResponse> getContent(@Login String memberId,
+                                                      @PathVariable("babyId") String babyId,
+                                                      @PathVariable("contentId") Long contentId) {
+        return ResponseEntity.ok(contentService.getContent(memberId, babyId, contentId));
     }
 
     @Operation(summary = "성장 앨범 댓글 보기 조회 요청")
@@ -196,8 +209,8 @@ public class ContentController {
     @IntervalServerErrorResponse
     @DeleteMapping("/baby/{babyId}/album/{contentId}")
     public ResponseEntity<Void> deleteContent(@Login String memberId,
-                                            @PathVariable("babyId") String babyId,
-                                            @PathVariable("contentId") Long contentId
+                                              @PathVariable("babyId") String babyId,
+                                              @PathVariable("contentId") Long contentId
     ) {
 
         contentService.deleteContent(memberId, babyId, contentId);

--- a/back/src/main/java/com/baba/back/content/repository/LikeRepository.java
+++ b/back/src/main/java/com/baba/back/content/repository/LikeRepository.java
@@ -11,8 +11,6 @@ import org.springframework.data.jpa.repository.Query;
 public interface LikeRepository extends JpaRepository<Like, Long> {
     Optional<Like> findByContentAndMember(Content content, Member member);
 
-    boolean existsByContentAndMember(Content content, Member member);
-
     @Query("select l from Like l where l.content = :content and l.deleted = false")
     List<Like> findAllByContent(Content content);
 }

--- a/back/src/main/java/com/baba/back/content/service/ContentService.java
+++ b/back/src/main/java/com/baba/back/content/service/ContentService.java
@@ -167,7 +167,7 @@ public class ContentService {
                                         content.getRelationName(),
                                         content.getContentDate(),
                                         content.getTitle(),
-                                        likeRepository.existsByContentAndMember(content, member),
+                                        isLike(member, content),
                                         content.getImageSource(),
                                         content.getCardStyle()
                                 ))
@@ -383,7 +383,6 @@ public class ContentService {
         findRelation(member, baby);
 
         List<Content> contents = contentRepository.findAllByBaby(baby);
-
         return new ContentsResponse(
                 contents.stream()
                         .map(
@@ -393,7 +392,7 @@ public class ContentService {
                                         content.getRelationName(),
                                         content.getContentDate(),
                                         content.getTitle(),
-                                        likeRepository.existsByContentAndMember(content, member),
+                                        isLike(member, content),
                                         content.getImageSource(),
                                         content.getCardStyle()
                                 ))
@@ -413,5 +412,28 @@ public class ContentService {
         validateContentOwner(content, member);
 
         contentRepository.delete(content);
+    }
+
+    public ContentResponse getContent(String memberId, String babyId, Long contentId) {
+        final Member member = findMember(memberId);
+        final Baby baby = findBaby(babyId);
+        findRelation(member, baby);
+        final Content content = findContent(contentId);
+
+        return new ContentResponse(
+                content.getId(),
+                content.getOwnerName(),
+                content.getRelationName(),
+                content.getContentDate(),
+                content.getTitle(),
+                isLike(member, content),
+                content.getImageSource(),
+                content.getCardStyle()
+        );
+    }
+
+    private boolean isLike(Member member, Content content) {
+        return likeRepository.findByContentAndMember(content, member).stream()
+                .anyMatch(like -> !like.isDeleted());
     }
 }

--- a/back/src/test/java/com/baba/back/AcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/AcceptanceTest.java
@@ -276,6 +276,13 @@ public class AcceptanceTest {
         );
     }
 
+    protected ExtractableResponse<Response> 성장_앨범_조회_요청(String accessToken, String babyId, Long contentId) {
+        return get(String.format("/%s/%s/%s/%s/%s",
+                        BASE_PATH, BABY_BASE_PATH, babyId, CONTENT_BASE_PATH, contentId),
+                Map.of("Authorization", "Bearer " + accessToken)
+        );
+    }
+
     protected Long getContentId(ExtractableResponse<Response> response) {
         final String location = getLocation(response);
         final String id = location.split("/")[4];

--- a/back/src/test/java/com/baba/back/content/repository/LikeRepositoryTest.java
+++ b/back/src/test/java/com/baba/back/content/repository/LikeRepositoryTest.java
@@ -54,8 +54,9 @@ class LikeRepositoryTest {
         likeRepository.save(new Like(savedMember, savedContent));
 
         // when
-        final boolean result = likeRepository.existsByContentAndMember(savedContent, savedMember);
-
+        final boolean result = likeRepository.findByContentAndMember(savedContent, savedMember)
+                .stream()
+                .anyMatch(like -> !like.isDeleted());
         // then
         assertThat(result).isTrue();
     }
@@ -68,7 +69,9 @@ class LikeRepositoryTest {
         final Content savedContent = contentRepository.save(컨텐츠10);
 
         // when
-        final boolean result = likeRepository.existsByContentAndMember(savedContent, savedMember);
+        final boolean result = likeRepository.findByContentAndMember(savedContent, savedMember)
+                .stream()
+                .anyMatch(like -> !like.isDeleted());
 
         // then
         assertThat(result).isFalse();

--- a/back/src/test/java/com/baba/back/content/service/ContentServiceTest.java
+++ b/back/src/test/java/com/baba/back/content/service/ContentServiceTest.java
@@ -323,8 +323,8 @@ class ContentServiceTest {
         given(babyRepository.findById(아기1.getId())).willReturn(Optional.of(아기1));
         given(relationRepository.findByMemberAndBaby(멤버1, 아기1)).willReturn(Optional.of(관계10));
         given(contentRepository.findByBabyYearAndMonth(아기1, year, month)).willReturn(List.of(컨텐츠10, 컨텐츠11));
-        given(likeRepository.existsByContentAndMember(컨텐츠10, 멤버1)).willReturn(true);
-        given(likeRepository.existsByContentAndMember(컨텐츠11, 멤버1)).willReturn(false);
+        given(likeRepository.findByContentAndMember(컨텐츠10, 멤버1)).willReturn(Optional.of(좋아요10));
+        given(likeRepository.findByContentAndMember(컨텐츠11, 멤버1)).willReturn(Optional.empty());
 
         // when
         final ContentsResponse response = contentService.getContents(멤버1.getId(), 아기1.getId(), year, month);


### PR DESCRIPTION
## 상세 내용
성장 앨범 한개 조회 API를 구현했습니다.

추가적으로 기존에 존재하던 성장 앨범 조회 API들에서 문제가 된 부분을 수정했습니다.

기존에는 성장 앨범 조회시 좋아요 여부를 조회할 때 좋아요가 존재하는지에 대해서 조회하였습니다.
이로인해 좋아요가 삭제되었어도 soft delete를 진행하므로 entity는 존재해서 true를 반환하고 있었습니다.
이 부분 수정했습니다.

Close #148
