### PR TITLE
아기 삭제 API를 구현한다.

### DIFF
--- a/back/src/main/java/com/baba/back/baby/controller/BabyController.java
+++ b/back/src/main/java/com/baba/back/baby/controller/BabyController.java
@@ -16,12 +16,14 @@ import com.baba.back.swagger.NotFoundResponse;
 import com.baba.back.swagger.OkResponse;
 import com.baba.back.swagger.UnAuthorizedResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotNull;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -107,5 +109,18 @@ public class BabyController {
                                                 @Login String memberId) {
         babyService.addBabyWithCode(request, memberId);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @Operation(summary = "아기 삭제 요청")
+    @ApiResponse(responseCode = "204", description = "NO CONTENT")
+    @BadRequestResponse
+    @UnAuthorizedResponse
+    @NotFoundResponse
+    @IntervalServerErrorResponse
+    @DeleteMapping("/baby/{babyId}")
+    public ResponseEntity<Void> deleteBaby(@PathVariable String babyId,
+                                                @Login String memberId) {
+        babyService.deleteBaby(memberId, babyId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/back/src/main/java/com/baba/back/baby/domain/invitation/InvitationCode.java
+++ b/back/src/main/java/com/baba/back/baby/domain/invitation/InvitationCode.java
@@ -38,6 +38,7 @@ public class InvitationCode {
         return this.relationName.getValue();
     }
 
+    // 삭제 시 오류 발생
     public LocalDateTime getExpiration() {
         return this.expiration.getValue();
     }

--- a/back/src/main/java/com/baba/back/baby/domain/invitation/Invitations.java
+++ b/back/src/main/java/com/baba/back/baby/domain/invitation/Invitations.java
@@ -2,6 +2,7 @@ package com.baba.back.baby.domain.invitation;
 
 import com.baba.back.baby.exception.InvitationCodeBadRequestException;
 import com.baba.back.baby.exception.InvitationsBadRequestException;
+import com.baba.back.common.Generated;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -39,5 +40,11 @@ public record Invitations(List<Invitation> values) {
                 .filter(invitationCode -> !invitationCode.isExpired(now))
                 .findAny()
                 .orElseThrow(() -> new InvitationCodeBadRequestException("초대 코드가 만료되었습니다."));
+    }
+
+
+    @Generated
+    public String getRelationGroupName() {
+        return this.values.get(0).getRelationGroup().getRelationGroupName();
     }
 }

--- a/back/src/main/java/com/baba/back/baby/dto/SearchInviteCodeResponse.java
+++ b/back/src/main/java/com/baba/back/baby/dto/SearchInviteCodeResponse.java
@@ -2,5 +2,5 @@ package com.baba.back.baby.dto;
 
 import java.util.List;
 
-public record SearchInviteCodeResponse(List<InviteCodeBabyResponse> babies, String relationName) {
+public record SearchInviteCodeResponse(List<InviteCodeBabyResponse> babies, String relationName, String relationGroup) {
 }

--- a/back/src/main/java/com/baba/back/baby/service/BabyService.java
+++ b/back/src/main/java/com/baba/back/baby/service/BabyService.java
@@ -22,6 +22,7 @@ import com.baba.back.baby.exception.RelationBadRequestException;
 import com.baba.back.baby.exception.RelationGroupNotFoundException;
 import com.baba.back.baby.repository.BabyRepository;
 import com.baba.back.baby.repository.InvitationRepository;
+import com.baba.back.common.Generated;
 import com.baba.back.oauth.domain.Picker;
 import com.baba.back.oauth.domain.member.Color;
 import com.baba.back.oauth.domain.member.Member;
@@ -40,7 +41,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-import lombok.Generated;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -248,7 +248,7 @@ public class BabyService {
         return new SearchInviteCodeResponse(
                 getInviteCodeBabyResponses(invitations),
                 invitationCode.getRelationName(),
-                getInvitationRelationGroup(invitations));
+                invitations.getRelationGroupName());
     }
 
     private List<InviteCodeBabyResponse> getInviteCodeBabyResponses(Invitations invitations) {
@@ -260,14 +260,6 @@ public class BabyService {
                     return new InviteCodeBabyResponse(baby.getName());
                 })
                 .toList();
-    }
-
-    private String getInvitationRelationGroup(Invitations invitations) {
-        return invitations.values().stream()
-                .map(Invitation::getRelationGroup)
-                .findFirst()
-                .orElseThrow(() -> new RelationGroupNotFoundException("초대코드에 해당하는 관계그룹이 존재하지 않습니다."))
-                .getRelationGroupName();
     }
 
     public void addBabyWithCode(InviteCodeRequest request, String memberId) {
@@ -330,9 +322,4 @@ public class BabyService {
 
         relationRepository.delete(relation);
     }
-
-
-    // TODO: 자신의 아기인 경우
-
-    // TODO: 다른 아기인 경우
 }

--- a/back/src/main/java/com/baba/back/content/domain/content/Content.java
+++ b/back/src/main/java/com/baba/back/content/domain/content/Content.java
@@ -19,6 +19,8 @@ import java.time.LocalDate;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -41,6 +43,7 @@ public class Content extends BaseEntity {
     private ImageSource imageSource;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Baby baby;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/back/src/main/java/com/baba/back/oauth/dto/BabyProfileResponse.java
+++ b/back/src/main/java/com/baba/back/oauth/dto/BabyProfileResponse.java
@@ -1,4 +1,6 @@
 package com.baba.back.oauth.dto;
 
-public record BabyProfileResponse(FamilyGroupResponse familyGroup, GroupResponse myGroup) {
+import java.time.LocalDate;
+
+public record BabyProfileResponse(LocalDate birthday, FamilyGroupResponse familyGroup, GroupResponse myGroup) {
 }

--- a/back/src/main/java/com/baba/back/oauth/service/MemberService.java
+++ b/back/src/main/java/com/baba/back/oauth/service/MemberService.java
@@ -314,12 +314,12 @@ public class MemberService {
         final FamilyGroupResponse familyGroupResponse = getFamilyGroup(familyRelationGroup);
 
         if (memberRelationGroup.isFamily()) {
-            return new BabyProfileResponse(familyGroupResponse, null);
+            return new BabyProfileResponse(baby.getBirthday(), familyGroupResponse, null);
         }
 
         final GroupResponse groupResponse = getGroupResponse(memberRelationGroup);
 
-        return new BabyProfileResponse(familyGroupResponse, groupResponse);
+        return new BabyProfileResponse(baby.getBirthday(), familyGroupResponse, groupResponse);
     }
 
     private Baby getBaby(String babyId) {

--- a/back/src/main/java/com/baba/back/relation/domain/RelationGroup.java
+++ b/back/src/main/java/com/baba/back/relation/domain/RelationGroup.java
@@ -19,6 +19,8 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -30,6 +32,7 @@ public class RelationGroup extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Baby baby;
 
     @Embedded

--- a/back/src/test/java/com/baba/back/AcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/AcceptanceTest.java
@@ -163,6 +163,11 @@ public class AcceptanceTest {
                 Map.of("Authorization", "Bearer " + accessToken), 아기_이름_변경_요청_데이터);
     }
 
+    protected ExtractableResponse<Response> 아기_삭제_요청(String accessToken, String babyId) {
+        return delete(String.format("/%s/%s/%s", BASE_PATH, BABY_BASE_PATH, babyId),
+                Map.of("Authorization", "Bearer " + accessToken));
+    }
+
     protected ExtractableResponse<Response> 성장앨범_생성_요청(String accessToken, String babyId, LocalDate now) {
         return thenExtract(
                 SimpleRestAssured.given()


### PR DESCRIPTION
## 상세 내용

아기 삭제 API를 구현하였습니다.

추가적으로
초대장 정보 확인 API에 relationGroup을,
다른 아기 프로필 조회 API에 아기의 생일을 추가로 응답하도록 변경하였습니다.

Close #147 
