### PR TITLE
refactor: 관계 그룹 로직 수정

### DIFF
--- a/back/src/main/java/com/baba/back/baby/controller/BabyController.java
+++ b/back/src/main/java/com/baba/back/baby/controller/BabyController.java
@@ -119,7 +119,7 @@ public class BabyController {
     @IntervalServerErrorResponse
     @DeleteMapping("/baby/{babyId}")
     public ResponseEntity<Void> deleteBaby(@PathVariable String babyId,
-                                                @Login String memberId) {
+                                           @Login String memberId) {
         babyService.deleteBaby(memberId, babyId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }

--- a/back/src/main/java/com/baba/back/baby/dto/IsMyBabyResponse.java
+++ b/back/src/main/java/com/baba/back/baby/dto/IsMyBabyResponse.java
@@ -1,6 +1,7 @@
 package com.baba.back.baby.dto;
 
-public record IsMyBabyResponse(String babyId, String groupColor, String name, boolean isMyBaby) implements Comparable<IsMyBabyResponse> {
+public record IsMyBabyResponse(String babyId, String groupColor, String name, boolean isMyBaby) implements
+        Comparable<IsMyBabyResponse> {
 
     @Override
     public int compareTo(IsMyBabyResponse o) {

--- a/back/src/main/java/com/baba/back/baby/service/BabyService.java
+++ b/back/src/main/java/com/baba/back/baby/service/BabyService.java
@@ -8,7 +8,6 @@ import com.baba.back.baby.domain.invitation.Invitation;
 import com.baba.back.baby.domain.invitation.InvitationCode;
 import com.baba.back.baby.domain.invitation.Invitations;
 import com.baba.back.baby.dto.BabiesResponse;
-import com.baba.back.baby.dto.BabyResponse;
 import com.baba.back.baby.dto.CreateBabyRequest;
 import com.baba.back.baby.dto.CreateInviteCodeRequest;
 import com.baba.back.baby.dto.CreateInviteCodeResponse;
@@ -156,7 +155,8 @@ public class BabyService {
 
     private List<IsMyBabyResponse> getBabyResponse(List<RelationGroup> groups, boolean isMyBaby) {
         return groups.stream()
-                .map(group -> new IsMyBabyResponse(group.getBabyId(), group.getGroupColor(), group.getBabyName(), isMyBaby))
+                .map(group -> new IsMyBabyResponse(group.getBabyId(), group.getGroupColor(), group.getBabyName(),
+                        isMyBaby))
                 .sorted()
                 .toList();
     }
@@ -316,7 +316,7 @@ public class BabyService {
         final Baby baby = findBaby(babyId);
         final Relation relation = findRelation(member, baby);
 
-        if(relation.isFamily()) {
+        if (relation.isFamily()) {
             babyRepository.delete(baby);
             return;
         }

--- a/back/src/main/java/com/baba/back/oauth/service/MemberService.java
+++ b/back/src/main/java/com/baba/back/oauth/service/MemberService.java
@@ -378,15 +378,26 @@ public class MemberService {
 
     public void updateGroup(String memberId, String groupName, UpdateGroupRequest request) {
         final Member member = getFirstMember(memberId);
-        final Baby firstBaby = findFirstBaby(member);
-
-        final List<RelationGroup> relationGroups = findGroupByGroupName(groupName, firstBaby);
+        final List<Baby> babies = findBabies(member);
+        final List<RelationGroup> relationGroups = findGroupByGroupName(groupName, babies);
 
         updateGroupNames(relationGroups, request.getRelationGroup());
     }
 
-    private List<RelationGroup> findGroupByGroupName(String groupName, Baby firstBaby) {
-        final List<RelationGroup> relationGroups = getRelationGroupsByBaby(firstBaby);
+    private List<Baby> findBabies(Member member) {
+        final List<Relation> relations = relationRepository.findAllByMemberAndRelationGroupFamily(member, true);
+
+        return relations.stream()
+                .map(relation -> {
+                    final RelationGroup relationGroup = relation.getRelationGroup();
+
+                    return relationGroup.getBaby();
+                })
+                .toList();
+    }
+
+    private List<RelationGroup> findGroupByGroupName(String groupName, List<Baby> babies) {
+        final List<RelationGroup> relationGroups = getRelationGroupsByBabies(babies);
         final List<RelationGroup> groupsByName = relationGroups.stream()
                 .filter(relationGroup -> relationGroup.hasEqualGroupName(groupName))
                 .toList();
@@ -421,9 +432,8 @@ public class MemberService {
     private List<Relation> getGroupMemberRelations(String memberId, String groupMemberId) {
         final Member member = getFirstMember(memberId);
         final Member groupMember = getFirstMember(groupMemberId);
-        final Baby firstBaby = findFirstBaby(member);
-
-        final List<RelationGroup> relationGroups = getRelationGroupsByBaby(firstBaby);
+        final List<Baby> babies = findBabies(member);
+        final List<RelationGroup> relationGroups = getRelationGroupsByBabies(babies);
 
         return getRelationsByMember(relationGroups, groupMember);
     }
@@ -450,9 +460,8 @@ public class MemberService {
 
     private List<RelationGroup> getMyRelationGroupsByGroup(String memberId, String groupName) {
         final Member member = getFirstMember(memberId);
-        final Baby firstBaby = findFirstBaby(member);
-
-        final List<RelationGroup> relationGroups = getRelationGroupsByBaby(firstBaby);
+        final List<Baby> babies = findBabies(member);
+        final List<RelationGroup> relationGroups = getRelationGroupsByBabies(babies);
 
         return relationGroups.stream()
                 .filter(relationGroup -> relationGroup.hasEqualGroupName(groupName))

--- a/back/src/test/java/com/baba/back/AcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/AcceptanceTest.java
@@ -70,7 +70,7 @@ public class AcceptanceTest {
         return 아기_등록_회원가입_요청(UUID.randomUUID().toString(), request);
     }
 
-    protected ExtractableResponse<Response> 아기_등록_회원가입_요청(String memberId, MemberSignUpRequest request) {
+    protected ExtractableResponse<Response> /**/아기_등록_회원가입_요청(String memberId, MemberSignUpRequest request) {
         final String signToken = signTokenProvider.createToken(memberId);
         return post(String.format("/%s/%s/%s", BASE_PATH, MEMBER_BASE_PATH, BABY_BASE_PATH),
                 Map.of("Authorization", "Bearer " + signToken), request);
@@ -218,7 +218,7 @@ public class AcceptanceTest {
         return 초대_코드_생성_요청(accessToken, 초대코드_생성_요청_데이터1);
     }
 
-    private ExtractableResponse<Response> 초대_코드_생성_요청(String accessToken, CreateInviteCodeRequest request) {
+    public ExtractableResponse<Response> 초대_코드_생성_요청(String accessToken, CreateInviteCodeRequest request) {
         return post(String.format("/%s/%s/invite-code", BASE_PATH, BABY_BASE_PATH),
                 Map.of("Authorization", "Bearer " + accessToken), request);
     }

--- a/back/src/test/java/com/baba/back/baby/acceptance/BabyAcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/baby/acceptance/BabyAcceptanceTest.java
@@ -7,6 +7,7 @@ import static com.baba.back.fixture.DomainFixture.아기1;
 import static com.baba.back.fixture.DomainFixture.아기2;
 import static com.baba.back.fixture.RequestFixture.멤버_가입_요청_데이터;
 import static com.baba.back.fixture.RequestFixture.초대코드_생성_요청_데이터2;
+import static com.baba.back.fixture.RequestFixture.초대코드_생성_요청_데이터3;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
@@ -20,8 +21,6 @@ import com.baba.back.baby.dto.CreateInviteCodeResponse;
 import com.baba.back.baby.dto.InviteCodeBabyResponse;
 import com.baba.back.baby.dto.IsMyBabyResponse;
 import com.baba.back.baby.dto.SearchInviteCodeResponse;
-import com.baba.back.content.dto.ContentResponse;
-import com.baba.back.content.dto.ContentsResponse;
 import com.baba.back.oauth.domain.Picker;
 import com.baba.back.oauth.domain.member.Color;
 import com.baba.back.oauth.dto.GroupResponseWithFamily;
@@ -85,41 +84,58 @@ class BabyAcceptanceTest extends AcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
 
-    @Test
-    void 초대_코드_생성_요청_시_초대_코드를_생성한다() {
-        // given
-        final String accessToken = toObject(아기_등록_회원가입_요청(), MemberSignUpResponse.class).accessToken();
+    @Nested
+    class 초대_코드_생성_요청_시_ {
 
-        // when
-        final ExtractableResponse<Response> response = 가족_초대_코드_생성_요청(accessToken);
+        @Test
+        void 초대_코드를_생성한다() {
+            // given
+            final String accessToken = toObject(아기_등록_회원가입_요청(), MemberSignUpResponse.class).accessToken();
 
-        // then
-        assertAll(
-                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
-                () -> assertThat(toObject(response, CreateInviteCodeResponse.class).inviteCode()).isNotBlank()
-        );
-    }
+            // when
+            final ExtractableResponse<Response> response = 가족_초대_코드_생성_요청(accessToken);
 
-    @Test
-    void 초대코드_생성_요청시_소속그룹과_관계명이_동일한_초대코드가_이미_존재하면_초대코드를_업데이트_한다() {
-        // given
-        final String accessToken = toObject(아기_등록_회원가입_요청(), MemberSignUpResponse.class).accessToken();
-        가족_초대_코드_생성_요청(accessToken);
+            // then
+            assertAll(
+                    () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
+                    () -> assertThat(toObject(response, CreateInviteCodeResponse.class).inviteCode()).isNotBlank()
+            );
+        }
 
-        // when
-        final ExtractableResponse<Response> response = 가족_초대_코드_생성_요청(accessToken);
+        @Test
+        void 그룹_정보를_변경한_후에도_초대_코드를_생성할_수_있다() {
+            // given
+            final String accessToken = toObject(아기_등록_회원가입_요청(), MemberSignUpResponse.class).accessToken();
+            외가_그룹_추가_요청(accessToken);
+            그룹_정보_변경_요청(accessToken);
 
-        // then
-        assertAll(
-                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
-                () -> assertThat(toObject(response, CreateInviteCodeResponse.class).inviteCode()).isNotBlank()
-        );
-    }
+            // when
+//            마이_그룹별_조회_요청(accessToken);
+            final ExtractableResponse<Response> response = 초대_코드_생성_요청(accessToken, 초대코드_생성_요청_데이터3);
 
-    // TODO: 2023/03/16 관계그룹 생성 로직 추가 이후 다른 그룹의 초대 코드 생성 테스트를 추가한다.
-    @Test
-    void 초대_코드_생성_요청_시_가족_그룹_이외의_초대_코드도_생성할수_있다() {
+            // then
+            assertAll(
+                    () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
+                    () -> assertThat(toObject(response, CreateInviteCodeResponse.class).inviteCode()).isNotBlank()
+            );
+        }
 
+
+        @Test
+        void 소속그룹과_관계명이_동일한_초대코드가_이미_존재하면_초대코드를_업데이트_한다() {
+            // given
+            final String accessToken = toObject(아기_등록_회원가입_요청(), MemberSignUpResponse.class).accessToken();
+            가족_초대_코드_생성_요청(accessToken);
+
+            // when
+            final ExtractableResponse<Response> response = 가족_초대_코드_생성_요청(accessToken);
+
+            // then
+            assertAll(
+                    () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
+                    () -> assertThat(toObject(response, CreateInviteCodeResponse.class).inviteCode()).isNotBlank()
+            );
+        }
     }
 
     @Test

--- a/back/src/test/java/com/baba/back/baby/service/BabyServiceTest.java
+++ b/back/src/test/java/com/baba/back/baby/service/BabyServiceTest.java
@@ -29,7 +29,6 @@ import static com.baba.back.fixture.RequestFixture.초대코드로_아기_추가
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -45,7 +44,6 @@ import com.baba.back.baby.domain.invitation.Code;
 import com.baba.back.baby.domain.invitation.Invitation;
 import com.baba.back.baby.domain.invitation.InvitationCode;
 import com.baba.back.baby.dto.BabiesResponse;
-import com.baba.back.baby.dto.BabyResponse;
 import com.baba.back.baby.dto.CreateBabyRequest;
 import com.baba.back.baby.dto.CreateInviteCodeResponse;
 import com.baba.back.baby.dto.InviteCodeBabyResponse;

--- a/back/src/test/java/com/baba/back/fixture/RequestFixture.java
+++ b/back/src/test/java/com/baba/back/fixture/RequestFixture.java
@@ -57,6 +57,8 @@ public class RequestFixture {
             "외가", "이모");
     public static final CreateInviteCodeRequest 초대코드_생성_요청_데이터2 = new CreateInviteCodeRequest(
             "가족", "아빠");
+    public static final CreateInviteCodeRequest 초대코드_생성_요청_데이터3 = new CreateInviteCodeRequest(
+            "친가", "고모");
     public static final InviteCodeRequest 초대코드로_아기_추가_요청_데이터 = new InviteCodeRequest("AAAAAA");
     public static final MemberUpdateRequest 마이_프로필_변경_요청_데이터 = new MemberUpdateRequest(
             "박재희2", "안녕하세요!", "PROFILE_W_2", "#81E0D5"

--- a/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
@@ -634,9 +634,9 @@ class MemberServiceTest {
         void 요청_받은_그룹명에_해당하는_그룹이_없으면_예외를_던진다() {
             // given
             given(memberRepository.findById(memberId)).willReturn(Optional.of(멤버1));
-            given(relationRepository.findFirstByMemberAndRelationGroupFamily(any(Member.class), eq(true)))
-                    .willReturn(Optional.of(관계10));
-            given(relationGroupRepository.findAllByBaby(any(Baby.class))).willReturn(List.of(관계그룹10));
+            given(relationRepository.findAllByMemberAndRelationGroupFamily(any(Member.class), eq(true)))
+                    .willReturn(List.of(관계10));
+            given(relationGroupRepository.findAllByBabyIn(anyList())).willReturn(List.of(관계그룹10));
 
             // when & then
             assertThatThrownBy(() -> memberService.updateGroup(memberId, groupName, 그룹_정보_변경_요청_데이터))
@@ -654,9 +654,9 @@ class MemberServiceTest {
                     .build();
 
             given(memberRepository.findById(memberId)).willReturn(Optional.of(멤버1));
-            given(relationRepository.findFirstByMemberAndRelationGroupFamily(any(Member.class), eq(true)))
-                    .willReturn(Optional.of(관계10));
-            given(relationGroupRepository.findAllByBaby(any(Baby.class))).willReturn(List.of(관계그룹10, relationGroup));
+            given(relationRepository.findAllByMemberAndRelationGroupFamily(any(Member.class), eq(true)))
+                    .willReturn(List.of(관계10));
+            given(relationGroupRepository.findAllByBabyIn(anyList())).willReturn(List.of(관계그룹10, relationGroup));
 
             // when
             memberService.updateGroup(memberId, groupName, 그룹_정보_변경_요청_데이터);
@@ -677,9 +677,9 @@ class MemberServiceTest {
             // given
             given(memberRepository.findById(memberId)).willReturn(Optional.of(멤버1));
             given(memberRepository.findById(groupMemberId)).willReturn(Optional.of(멤버3));
-            given(relationRepository.findFirstByMemberAndRelationGroupFamily(any(Member.class), eq(true)))
-                    .willReturn(Optional.of(관계10));
-            given(relationGroupRepository.findAllByBaby(any(Baby.class))).willReturn(List.of(관계그룹10, 관계그룹11));
+            given(relationRepository.findAllByMemberAndRelationGroupFamily(any(Member.class), eq(true)))
+                    .willReturn(List.of(관계10));
+            given(relationGroupRepository.findAllByBabyIn(anyList())).willReturn(List.of(관계그룹10, 관계그룹11));
             given(relationRepository.findAllByRelationGroupIn(anyList())).willReturn(List.of(관계10, 관계11));
 
             // when & then
@@ -698,9 +698,9 @@ class MemberServiceTest {
 
             given(memberRepository.findById(memberId)).willReturn(Optional.of(멤버1));
             given(memberRepository.findById(groupMemberId)).willReturn(Optional.of(멤버3));
-            given(relationRepository.findFirstByMemberAndRelationGroupFamily(any(Member.class), eq(true)))
-                    .willReturn(Optional.of(관계10));
-            given(relationGroupRepository.findAllByBaby(any(Baby.class))).willReturn(List.of(관계그룹10, 관계그룹11));
+            given(relationRepository.findAllByMemberAndRelationGroupFamily(any(Member.class), eq(true)))
+                    .willReturn(List.of(관계10));
+            given(relationGroupRepository.findAllByBabyIn(anyList())).willReturn(List.of(관계그룹10, 관계그룹11));
             given(relationRepository.findAllByRelationGroupIn(anyList())).willReturn(List.of(관계10, 관계11, relation));
 
             // when
@@ -728,9 +728,9 @@ class MemberServiceTest {
 
             given(memberRepository.findById(memberId)).willReturn(Optional.of(멤버1));
             given(memberRepository.findById(groupMemberId)).willReturn(Optional.of(멤버3));
-            given(relationRepository.findFirstByMemberAndRelationGroupFamily(any(Member.class), eq(true)))
-                    .willReturn(Optional.of(관계10));
-            given(relationGroupRepository.findAllByBaby(any(Baby.class))).willReturn(List.of(관계그룹10, 관계그룹11));
+            given(relationRepository.findAllByMemberAndRelationGroupFamily(any(Member.class), eq(true)))
+                    .willReturn(List.of(관계10));
+            given(relationGroupRepository.findAllByBabyIn(anyList())).willReturn(List.of(관계그룹10, 관계그룹11));
             given(relationRepository.findAllByRelationGroupIn(anyList())).willReturn(List.of(관계10, 관계11, relation));
 
             // when
@@ -758,9 +758,9 @@ class MemberServiceTest {
                     .build();
 
             given(memberRepository.findById(memberId)).willReturn(Optional.of(멤버1));
-            given(relationRepository.findFirstByMemberAndRelationGroupFamily(any(Member.class), eq(true)))
-                    .willReturn(Optional.of(관계10));
-            given(relationGroupRepository.findAllByBaby(any(Baby.class))).willReturn(List.of(관계그룹10, relationGroup));
+            given(relationRepository.findAllByMemberAndRelationGroupFamily(any(Member.class), eq(true)))
+                    .willReturn(List.of(관계10));
+            given(relationGroupRepository.findAllByBabyIn(anyList())).willReturn(List.of(관계그룹10, relationGroup));
 
             // when
             memberService.deleteGroup(memberId, groupName);


### PR DESCRIPTION
## 상세 내용
클라이언트 측에서 "그룹 수정 -> 초대 코드 생성" 순으로 API 호출 시 오류가 발생한다는 제보를 하였습니다.
확인 결과, 그룹의 수정 · 삭제 로직에서 자신의 모든 아기에 대한 그룹이 아닌
첫 번째 아기의 그룹에 대해서만 수정 · 삭제를 하고 있는 것을 파악하였습니다.

이에 자신의 모든 아기에 대한 그룹을 수정 · 삭제하도록 로직을 변경하였습니다.