### PR TITLE
fix: 다른 아기 프로필 조회 API를 수정한다.

### DIFF
--- a/back/src/main/java/com/baba/back/baby/controller/BabyController.java
+++ b/back/src/main/java/com/baba/back/baby/controller/BabyController.java
@@ -16,7 +16,6 @@ import com.baba.back.swagger.NotFoundResponse;
 import com.baba.back.swagger.OkResponse;
 import com.baba.back.swagger.UnAuthorizedResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotNull;
 import java.net.URI;

--- a/back/src/main/java/com/baba/back/oauth/service/MemberService.java
+++ b/back/src/main/java/com/baba/back/oauth/service/MemberService.java
@@ -353,7 +353,7 @@ public class MemberService {
 
     private List<BabyResponse> getBabies(RelationGroup relationGroup) {
         final Member familyMember = getFirstMember(relationGroup);
-        final List<Relation> relations = relationRepository.findAllByMember(familyMember);
+        final List<Relation> relations = relationRepository.findAllByMemberAndRelationGroupFamily(familyMember, true);
 
         return relations.stream()
                 .map(relation -> {

--- a/back/src/test/java/com/baba/back/oauth/acceptance/MemberAcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/acceptance/MemberAcceptanceTest.java
@@ -507,7 +507,8 @@ class MemberAcceptanceTest extends AcceptanceTest {
             final String invitedMemberBabyId = getBabyId(아기_추가_응답);
 
             // when
-            final ExtractableResponse<Response> response = 다른_아기_프로필_조회_요청(invitedMemberAccessToken, invitedMemberBabyId);
+            final ExtractableResponse<Response> response = 다른_아기_프로필_조회_요청(invitedMemberAccessToken,
+                    invitedMemberBabyId);
             final BabyProfileResponse babyProfileResponse = toObject(response, BabyProfileResponse.class);
 
             // then

--- a/back/src/test/java/com/baba/back/oauth/acceptance/MemberAcceptanceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/acceptance/MemberAcceptanceTest.java
@@ -485,5 +485,38 @@ class MemberAcceptanceTest extends AcceptanceTest {
                     () -> assertThat(babyProfileResponse.myGroup().members()).hasSize(1)
             );
         }
+
+        @Test
+        void 자신의_아기를_추가해도_조회하는_아기가_자신의_아기는_아니라면_가족_그룹의_정보와_자신의_소속_그룹의_정보를_조회한다() {
+            // given
+            final String memberId1 = "memberId1";
+            final String memberId2 = "memberId2";
+
+            final ExtractableResponse<Response> 아기_등록_회원가입_응답 = 아기_등록_회원가입_요청(memberId1);
+            final String accessToken = toObject(아기_등록_회원가입_응답, MemberSignUpResponse.class).accessToken();
+
+            외가_그룹_추가_요청(accessToken);
+
+            final ExtractableResponse<Response> 외가_초대_코드_생성_응답 = 외가_초대_코드_생성_요청(accessToken);
+            final String code = toObject(외가_초대_코드_생성_응답, CreateInviteCodeResponse.class).inviteCode();
+
+            final ExtractableResponse<Response> 초대코드로_회원가입_응답 = 초대코드로_회원가입_요청(memberId2, code);
+            final String invitedMemberAccessToken = toObject(초대코드로_회원가입_응답, MemberSignUpResponse.class).accessToken();
+
+            final ExtractableResponse<Response> 아기_추가_응답 = 아기_추가_요청(invitedMemberAccessToken);
+            final String invitedMemberBabyId = getBabyId(아기_추가_응답);
+
+            // when
+            final ExtractableResponse<Response> response = 다른_아기_프로필_조회_요청(invitedMemberAccessToken, invitedMemberBabyId);
+            final BabyProfileResponse babyProfileResponse = toObject(response, BabyProfileResponse.class);
+
+            // then
+            assertAll(
+                    () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                    () -> assertThat(babyProfileResponse.familyGroup().members()).hasSize(1),
+                    () -> assertThat(babyProfileResponse.familyGroup().babies()).hasSize(1),
+                    () -> assertThat(babyProfileResponse.myGroup()).isNull()
+            );
+        }
     }
 }

--- a/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
@@ -515,7 +515,8 @@ class MemberServiceTest {
                     .willReturn(Optional.of(관계그룹10));
 
             given(relationRepository.findFirstByRelationGroup(any(RelationGroup.class))).willReturn(Optional.of(관계10));
-            given(relationRepository.findAllByMemberAndRelationGroupFamily(any(Member.class), eq(true))).willReturn(List.of(관계10, 관계20));
+            given(relationRepository.findAllByMemberAndRelationGroupFamily(any(Member.class), eq(true))).willReturn(
+                    List.of(관계10, 관계20));
             given(relationRepository.findAllByRelationGroup(any(RelationGroup.class))).willReturn(List.of(관계10, 관계11));
 
             // when
@@ -570,7 +571,8 @@ class MemberServiceTest {
 
             given(relationRepository.findFirstByRelationGroup(any(RelationGroup.class))).willReturn(
                     Optional.of(관계10));
-            given(relationRepository.findAllByMemberAndRelationGroupFamily(any(Member.class), eq(true))).willReturn(List.of(관계10, 관계20));
+            given(relationRepository.findAllByMemberAndRelationGroupFamily(any(Member.class), eq(true))).willReturn(
+                    List.of(관계10, 관계20));
             given(relationRepository.findAllByRelationGroup(any(RelationGroup.class))).willReturn(
                     List.of(관계10, 관계11), List.of(관계12));
 

--- a/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
+++ b/back/src/test/java/com/baba/back/oauth/service/MemberServiceTest.java
@@ -515,7 +515,7 @@ class MemberServiceTest {
                     .willReturn(Optional.of(관계그룹10));
 
             given(relationRepository.findFirstByRelationGroup(any(RelationGroup.class))).willReturn(Optional.of(관계10));
-            given(relationRepository.findAllByMember(any(Member.class))).willReturn(List.of(관계10, 관계20));
+            given(relationRepository.findAllByMemberAndRelationGroupFamily(any(Member.class), eq(true))).willReturn(List.of(관계10, 관계20));
             given(relationRepository.findAllByRelationGroup(any(RelationGroup.class))).willReturn(List.of(관계10, 관계11));
 
             // when
@@ -570,7 +570,7 @@ class MemberServiceTest {
 
             given(relationRepository.findFirstByRelationGroup(any(RelationGroup.class))).willReturn(
                     Optional.of(관계10));
-            given(relationRepository.findAllByMember(any(Member.class))).willReturn(List.of(관계10, 관계20));
+            given(relationRepository.findAllByMemberAndRelationGroupFamily(any(Member.class), eq(true))).willReturn(List.of(관계10, 관계20));
             given(relationRepository.findAllByRelationGroup(any(RelationGroup.class))).willReturn(
                     List.of(관계10, 관계11), List.of(관계12));
 


### PR DESCRIPTION
## 상세 내용
사용자 초대 -> 초대된 사용자 아기 추가 -> 추가된 아기의 프로필 조회

위의 시나리오에서 추가된 아기의 프로필 조회시 가족 그룹의 아기 뿐만 아니라 팔로우 중인 다른 아기의 정보까지 같이 조회되는 버그가 있었습니다.

이를 가족 그룹의 아기만 조회하는 로직으로 수정하였습니다.

Close #157 
